### PR TITLE
Remove references to external W3 package

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,5 @@
 Doxymacs depends on the following packages:
 
-- W3      http://www.cs.indiana.edu/usr/local/www/elisp/w3/docs.html
 - libxml2 http://www.libxml.org/
 
 Be sure these are properly configured and installed before proceeding.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ GNU General Public License for more details.
 
 Doxymacs depends on the following packages:
 
-- W3      http://www.cs.indiana.edu/usr/local/www/elisp/w3/docs.html
 - libxml2 http://www.libxml.org/
 
 Be sure these are properly configured and installed before proceeding.

--- a/lisp/doxymacs.el.in
+++ b/lisp/doxymacs.el.in
@@ -32,7 +32,6 @@
 ;;
 ;; Doxymacs depends on the following packages:
 ;;
-;; - W3      http://www.cs.indiana.edu/usr/local/www/elisp/w3/docs.html
 ;; - libxml2 http://www.libxml.org/
 ;;
 ;; Be sure these are properly configured and installed before proceeding.


### PR DESCRIPTION
We have not depended on W3 since commit 6b725d1641e316e352b99e5ca6acad87410b9e97 (dated 2005-04-13!).  This pull request removes references to W3 in the documentation.