### PR TITLE
re-indent lisp source files to recommended indent settings for lisp

### DIFF
--- a/lisp/doxymacs.el.in
+++ b/lisp/doxymacs.el.in
@@ -263,9 +263,9 @@
 Each item on the list is a list of the form (DIR-REGEXP XML URL)
 where:
 
- DIR-REGEXP is a regular expression that matches a directory;
- XML is the file name or URL of the corresponding Doxygen XML tags; and
- URL is the URL of the Doxygen documentation that matches that directory.
+DIR-REGEXP is a regular expression that matches a directory;
+XML is the file name or URL of the corresponding Doxygen XML tags; and
+URL is the URL of the Doxygen documentation that matches that directory.
 
 For example, if all the files in /home/me/project/foo have their documentation
 at http://someplace.com/doc/foo/ and the XML tags file is at
@@ -274,12 +274,12 @@ http://someplace.com/doc/foo/foo.xml, and all the files in
 file:///home/me/project/bar/doc/ and the XML tags file is at
 /home/me/project/bar/doc/bar.xml, then you would set this list to
 
-    '((\"^/home/me/project/foo/\"
-       \"http://someplace.com/doc/foo/foo.xml\"
-       \"http://someplace.com/doc/foo/\")
-      (\"^/home/me/project/bar/\"
-       \"~/project/bar/doc/bar.xml\"
-       \"file:///home/me/project/bar/doc/\"))"
+'((\"^/home/me/project/foo/\"
+\"http://someplace.com/doc/foo/foo.xml\"
+\"http://someplace.com/doc/foo/\")
+(\"^/home/me/project/bar/\"
+\"~/project/bar/doc/bar.xml\"
+\"file:///home/me/project/bar/doc/\"))"
   :type 'list
   :group 'doxymacs)
 
@@ -304,7 +304,7 @@ to anything else will generate errors."
 If nil, then use the default dictated by `doxymacs-doxygen-style'.  Otherwise,
 must be one of \"@\" or \"\\\"."
   :type '(choice (const :tag "None" nil)
-		 string)
+                 string)
   :group 'doxymacs)
 
 (defcustom doxymacs-use-external-xml-parser
@@ -314,7 +314,7 @@ For smallish tag files, you are better off with the internal parser.
 For larger tag files, you are better off with the external one.
 Set to non-nil to use the external XML parser."
   :type '(choice (const :tag "Yes" t)
-		 (const :tag "No" nil))
+                 (const :tag "No" nil))
   :group 'doxymacs)
 
 (defcustom doxymacs-external-xml-parser-executable
@@ -394,7 +394,7 @@ are typedefs of void.  Example: \"void tVOID\"."
 If nil, use a default one based on the current style as indicated by
 `doxymacs-doxygen-style'."
   :type '(choice (const :tag "None" nil)
-		 string)
+                 string)
   :group 'doxymacs)
 
 (defcustom doxymacs-member-comment-end
@@ -405,7 +405,7 @@ If nil, use a default one based on the current style as indicated by
 
 Should be an empty string if comments are terminated by end-of-line."
   :type '(choice (const :tag "None" nil)
-		 string)
+                 string)
   :group 'doxymacs)
 
 (defcustom doxymacs-group-comment-start
@@ -414,7 +414,7 @@ Should be an empty string if comments are terminated by end-of-line."
 If nil, then a default template based on the current style as indicated
 by `doxymacs-doxygen-style' will be used."
   :type '(choice (const :tag "None" nil)
-		 string)
+                 string)
   :group 'doxymacs)
 
 (defcustom doxymacs-group-comment-end
@@ -423,7 +423,7 @@ by `doxymacs-doxygen-style' will be used."
 If nil, then a default template based on the current style as indicated
 by `doxymacs-doxygen-style' will be used."
   :type '(choice (const :tag "None" nil)
-		 string)
+                 string)
   :group 'doxymacs)
 
 ;; End of customisable variables
@@ -432,8 +432,8 @@ by `doxymacs-doxygen-style' will be used."
   "The buffers with our Doxygen tags; a list of the form
 '((DIR . BUFFER) (...)) where:
 
- DIR is one of the directories from `doxymacs-doxygen-dirs'; and
- BUFFER is the buffer holding the Doxygen tags for that DIR.")
+DIR is one of the directories from `doxymacs-doxygen-dirs'; and
+BUFFER is the buffer holding the Doxygen tags for that DIR.")
 
 ;; The structure of this list has been chosen for ease of use in the
 ;; completion functions.
@@ -441,16 +441,16 @@ by `doxymacs-doxygen-style' will be used."
   "The lists with doxytags completions.
 The structure is as follows:
 
- ( (dir1 . (symbol-1 . ((description-1a . url-1a) (description-1b . url-1b)))
-           (symbol-2 . ((description-2a . url-2a))))
-   ... )
+( (dir1 . (symbol-1 . ((description-1a . url-1a) (description-1b . url-1b)))
+(symbol-2 . ((description-2a . url-2a))))
+... )
 
 where
 
-  dir1 is one of the directories from `doxymacs-doxygen-dirs';
-  symbol-1 is one of the symbols in the associated Doxygen XML file;
-  description-1a is one of symbol-1's description from the XML file; and
-  url-1a is the associated URL.")
+dir1 is one of the directories from `doxymacs-doxygen-dirs';
+symbol-1 is one of the symbols in the associated Doxygen XML file;
+description-1a is one of symbol-1's description from the XML file; and
+url-1a is the associated URL.")
 
 (defvar doxymacs-current-completion-list nil
   "The current list we are building")
@@ -492,19 +492,19 @@ Key bindings:
     (when (boundp 'filladapt-token-table)
       ;; add tokens to filladapt to match doxygen markup
       (let ((bullet-regexp (concat "[@\\]"
-				   "\\(param\\(?:\\s-*"
-				   "\\[\\(?:in\\|out\\|in,out\\)\\]\\)?"
-				   "\\s-+\\sw+"
-				   "\\|tparam\\s-+\\sw+"
-				   "\\|return\\|attention\\|note"
-				   "\\|brief\\|li\\|arg\\|remarks"
-				   "\\|invariant\\|post\\|pre"
-				   "\\|todo\\|warning\\|bug"
-				   "\\|deprecated\\|since\\|test\\)")))
-	(unless (assoc bullet-regexp filladapt-token-table)
-	  (setq filladapt-token-table
-		(append filladapt-token-table
-			(list (list bullet-regexp 'bullet)))))))))
+                                   "\\(param\\(?:\\s-*"
+                                   "\\[\\(?:in\\|out\\|in,out\\)\\]\\)?"
+                                   "\\s-+\\sw+"
+                                   "\\|tparam\\s-+\\sw+"
+                                   "\\|return\\|attention\\|note"
+                                   "\\|brief\\|li\\|arg\\|remarks"
+                                   "\\|invariant\\|post\\|pre"
+                                   "\\|todo\\|warning\\|bug"
+                                   "\\|deprecated\\|since\\|test\\)")))
+        (unless (assoc bullet-regexp filladapt-token-table)
+          (setq filladapt-token-table
+                (append filladapt-token-table
+                        (list (list bullet-regexp 'bullet)))))))))
 
 ;; Keymap
 
@@ -512,35 +512,35 @@ Key bindings:
   "Keymap for doxymacs minor mode.")
 
 (define-key doxymacs-mode-map "\C-cd?"
-  'doxymacs-lookup)
+            'doxymacs-lookup)
 (define-key doxymacs-mode-map "\C-cdr"
-  'doxymacs-rescan-tags)
+            'doxymacs-rescan-tags)
 
 (define-key doxymacs-mode-map "\C-cd\r"
-  'doxymacs-insert-command)
+            'doxymacs-insert-command)
 (define-key doxymacs-mode-map "\C-cdf"
-  'doxymacs-insert-function-comment)
+            'doxymacs-insert-function-comment)
 (define-key doxymacs-mode-map "\C-cdi"
-  'doxymacs-insert-file-comment)
+            'doxymacs-insert-file-comment)
 (define-key doxymacs-mode-map "\C-cdm"
-  'doxymacs-insert-blank-multiline-comment)
+            'doxymacs-insert-blank-multiline-comment)
 (define-key doxymacs-mode-map "\C-cds"
-  'doxymacs-insert-blank-singleline-comment)
+            'doxymacs-insert-blank-singleline-comment)
 (define-key doxymacs-mode-map "\C-cd;"
-  'doxymacs-insert-member-comment)
+            'doxymacs-insert-member-comment)
 (define-key doxymacs-mode-map "\C-cd@"
-  'doxymacs-insert-grouping-comments)
+            'doxymacs-insert-grouping-comments)
 
 
 ;;;###autoload
 (or (assoc 'doxymacs-mode minor-mode-alist)
     (setq minor-mode-alist
-	  (cons '(doxymacs-mode " doxy") minor-mode-alist)))
+          (cons '(doxymacs-mode " doxy") minor-mode-alist)))
 
 (or (assoc 'doxymacs-mode minor-mode-map-alist)
     (setq minor-mode-map-alist
-	  (cons (cons 'doxymacs-mode doxymacs-mode-map)
-		minor-mode-map-alist)))
+          (cons (cons 'doxymacs-mode doxymacs-mode-map)
+                minor-mode-map-alist)))
 
 ;; This stuff has to do with fontification
 ;; Thanks to Alec Panovici for the idea.
@@ -550,19 +550,19 @@ Key bindings:
    (list
     ;; One shot keywords that take no arguments
     (concat "\\([@\\\\]\\(brief\\|li\\|\\(end\\)?code\\|sa"
-	    "\\|note\\|\\(end\\)?verbatim\\|return\\|arg\\|fn"
-	    "\\|hideinitializer\\|showinitializer"
-	    ;; FIXME
-	    ;; How do I get & # < > % to work?
-	    ;;"\\|\\\\&\\|\\$\\|\\#\\|<\\|>\\|\\%"
-	    "\\|\\$"
-	    "\\|internal\\|nosubgrouping\\|author\\|date\\|endif"
-	    "\\|invariant\\|post\\|pre\\|remarks\\|since\\|test\\|version"
-	    "\\|\\(end\\)?htmlonly\\|\\(end\\)?latexonly\\|f\\$\\|file"
-	    "\\|\\(end\\)?xmlonly\\|\\(end\\)?manonly\\|property"
-	    "\\|mainpage\\|name\\|overload\\|typedef\\|deprecated\\|par"
-	    "\\|addindex\\|line\\|skip\\|skipline\\|until\\|see"
-	    "\\|endlink\\|callgraph\\|endcond\\|else\\)\\)\\>")
+            "\\|note\\|\\(end\\)?verbatim\\|return\\|arg\\|fn"
+            "\\|hideinitializer\\|showinitializer"
+            ;; FIXME
+            ;; How do I get & # < > % to work?
+            ;;"\\|\\\\&\\|\\$\\|\\#\\|<\\|>\\|\\%"
+            "\\|\\$"
+            "\\|internal\\|nosubgrouping\\|author\\|date\\|endif"
+            "\\|invariant\\|post\\|pre\\|remarks\\|since\\|test\\|version"
+            "\\|\\(end\\)?htmlonly\\|\\(end\\)?latexonly\\|f\\$\\|file"
+            "\\|\\(end\\)?xmlonly\\|\\(end\\)?manonly\\|property"
+            "\\|mainpage\\|name\\|overload\\|typedef\\|deprecated\\|par"
+            "\\|addindex\\|line\\|skip\\|skipline\\|until\\|see"
+            "\\|endlink\\|callgraph\\|endcond\\|else\\)\\)\\>")
     '(0 font-lock-keyword-face prepend))
    ;; attention, warning, etc. given a different font
    (list
@@ -571,14 +571,14 @@ Key bindings:
    ;; keywords that take a variable name as an argument
    (list
     (concat "\\([@\\\\]\\(param\\(?:\\s-*\\[\\(?:in\\|out\\|in,out\\)\\]\\)?"
-	    "\\|tparam\\|a\\|namespace\\|relates\\(also\\)?"
-	    "\\|var\\|def\\)\\)\\s-+\\(\\sw+\\)")
+            "\\|tparam\\|a\\|namespace\\|relates\\(also\\)?"
+            "\\|var\\|def\\)\\)\\s-+\\(\\sw+\\)")
     '(1 font-lock-keyword-face prepend)
     '(4 font-lock-variable-name-face prepend))
    ;; keywords that take a type name as an argument
    (list
     (concat "\\([@\\\\]\\(class\\|struct\\|union\\|exception\\|enum"
-	    "\\|throw\\|interface\\|protocol\\)\\)\\s-+\\(\\(\\sw\\|:\\)+\\)")
+            "\\|throw\\|interface\\|protocol\\)\\)\\s-+\\(\\(\\sw\\|:\\)+\\)")
     '(1 font-lock-keyword-face prepend)
     '(3 font-lock-type-face prepend))
    ;; keywords that take a function name as an argument
@@ -609,8 +609,8 @@ Key bindings:
    ;; one argument that can contain arbitrary non-whitespace stuff
    (list
     (concat "\\([@\\\\]\\(link\\|copydoc\\|xrefitem"
-	    "\\|if\\(not\\)?\\|elseif\\)\\)"
-	    "\\s-+\\([^ \t\n]+\\)")
+            "\\|if\\(not\\)?\\|elseif\\)\\)"
+            "\\s-+\\([^ \t\n]+\\)")
     '(1 font-lock-keyword-face prepend)
     '(4 font-lock-string-face prepend))
    ;; one optional argument that can contain arbitrary non-whitespace stuff
@@ -626,14 +626,14 @@ Key bindings:
    ;; one argument that has to be a filename
    (list
     (concat "\\([@\\\\]\\(example\\|\\(dont\\)?include\\|includelineno"
-	    "\\|htmlinclude\\|verbinclude\\)\\)\\s-+"
-	    "\\(\"?[~:\\/a-zA-Z0-9_. ]+\"?\\)")
+            "\\|htmlinclude\\|verbinclude\\)\\)\\s-+"
+            "\\(\"?[~:\\/a-zA-Z0-9_. ]+\"?\\)")
     '(1 font-lock-keyword-face prepend)
     '(4 font-lock-string-face prepend))
    ;; dotfile <file> ["caption"]
    (list
     (concat "\\([@\\\\]dotfile\\)\\s-+"
-	    "\\(\"?[~:\\/a-zA-Z0-9_. ]+\"?\\)\\(\\s-+\"[^\"]+\"\\)?")
+            "\\(\"?[~:\\/a-zA-Z0-9_. ]+\"?\\)\\(\\s-+\"[^\"]+\"\\)?")
     '(1 font-lock-keyword-face prepend)
     '(2 font-lock-string-face prepend)
     '(3 font-lock-string-face prepend t))
@@ -648,8 +648,8 @@ Key bindings:
    ;; one argument that has to be a word
    (list
     (concat "\\([@\\\\]\\(addtogroup\\|defgroup\\|weakgroup"
-	    "\\|page\\|anchor\\|ref\\|section\\|subsection"
-	    "\\)\\)\\s-+\\(\\sw+\\)")
+            "\\|page\\|anchor\\|ref\\|section\\|subsection"
+            "\\)\\)\\s-+\\(\\sw+\\)")
     '(1 font-lock-keyword-face prepend)
     '(3 font-lock-string-face prepend))))
 
@@ -662,8 +662,8 @@ Key bindings:
       (font-lock-add-keywords nil doxymacs-doxygen-keywords)
     ;; Use old-school way
     (let ((old (if (eq (car-safe font-lock-keywords) t)
-		 (cdr font-lock-keywords)
-	       font-lock-keywords)))
+                   (cdr font-lock-keywords)
+                 font-lock-keywords)))
       (setq font-lock-keywords (append old doxymacs-doxygen-keywords)))))
 
 
@@ -682,23 +682,23 @@ element"
   (catch 'done
     (while a
       (if (string-match (caar a) f)
-	  (throw 'done
-		 (cdar a))
-	(setq a (cdr a))))))
+          (throw 'done
+                 (cdar a))
+        (setq a (cdr a))))))
 
 (defun doxymacs-filename-to-xml (f)
   "Lookup filename in `doxymacs-doxygen-dirs' and return associated XML tags
 file."
   (let ((xml-url (doxymacs-filename-to-element f doxymacs-doxygen-dirs)))
     (if xml-url
-	(car xml-url))))
+        (car xml-url))))
 
 (defun doxymacs-filename-to-url (f)
   "Lookup filename in `doxymacs-doxygen-dirs' and return associated Doxygen
 documentation URL root."
   (let ((xml-url (doxymacs-filename-to-element f doxymacs-doxygen-dirs)))
     (if xml-url
-	(cadr xml-url))))
+        (cadr xml-url))))
 
 (defun doxymacs-filename-to-buffer (f)
   "Lookup filename in `doxymacs-tags-buffers' and return associated buffer."
@@ -714,20 +714,20 @@ completion list."
   (catch 'done
     (let ((dirs doxymacs-doxygen-dirs))
       (while dirs
-	(if (string-match (caar dirs) f)
-	    (throw 'done
-		   (caar dirs))
-	  (setq dirs (cdr dirs)))))))
+        (if (string-match (caar dirs) f)
+            (throw 'done
+                   (caar dirs))
+          (setq dirs (cdr dirs)))))))
 
 (defun doxymacs-set-dir-element (dir l e)
   "Set the element associated with dir in l to e."
   (catch 'done
     (while l
       (let ((pair (car l)))
-	(if (string= (car pair) dir)
-	    (throw 'done
-		   (setcdr pair e))
-	  (setq l (cdr l)))))))
+        (if (string= (car pair) dir)
+            (throw 'done
+                   (setcdr pair e))
+          (setq l (cdr l)))))))
 
 (defun doxymacs-set-tags-buffer (dir buffer)
   "Set the buffer associated with dir in `doxymacs-tags-buffers' to the given
@@ -742,29 +742,29 @@ to comp-list."
 (defun doxymacs-url-exists-p (url)
   "Return t iff the URL exists."
   (let* ((urlobj (url-generic-parse-url url))
-	 (type (url-type urlobj))
-	 (exists nil))
+         (type (url-type urlobj))
+         (exists nil))
     (cond
      ((equal type "http")
       (cond
        ;; Try url-file-exists, if it exists
        ((fboundp 'url-file-exists)
-	(setq exists (url-file-exists url)))
+        (setq exists (url-file-exists url)))
        ;; Otherwise, try url-file-exists-p (newer url.el)
        ((fboundp 'url-file-exists-p)
-	(setq exists (url-file-exists-p url)))
+        (setq exists (url-file-exists-p url)))
        ;; Otherwise, try wget
        ((executable-find (if (eq system-type 'windows-nt) "wget.exe" "wget"))
-	(if (string-match "200 OK"
-			  (shell-command-to-string
-			   (concat "wget -S --spider " url)))
-	    (setq exists t)))
+        (if (string-match "200 OK"
+                          (shell-command-to-string
+                           (concat "wget -S --spider " url)))
+            (setq exists t)))
        ;; Otherwise, try lynx
        ((executable-find (if (eq system-type 'windows-nt) "lynx.exe" "lynx"))
-	(if (string-match "200 OK"
-			  (shell-command-to-string
-			   (concat "lynx -head -source " url)))
-	    (setq exists t)))
+        (if (string-match "200 OK"
+                          (shell-command-to-string
+                           (concat "lynx -head -source " url)))
+            (setq exists t)))
        ;; Give up.
        (t (error "Could not find url-file-exists, url-file-exists-p, wget or lynx"))))
      ((equal type "file")
@@ -775,99 +775,99 @@ to comp-list."
 (defun doxymacs-load-tags (f)
   "Loads a Doxygen generated XML tags file into the buffer *doxytags*."
   (let* ((tags-buffer (doxymacs-filename-to-buffer f))
-	 (dir (doxymacs-filename-to-dir f))
-	 (xml (doxymacs-filename-to-xml f)))
+         (dir (doxymacs-filename-to-dir f))
+         (xml (doxymacs-filename-to-xml f)))
     (if (and xml dir)
-	(if (or (eq tags-buffer nil)
-		(eq (buffer-live-p tags-buffer) nil))
-	    (let ((new-buffer (generate-new-buffer "*doxytags")))
-	      (if tags-buffer
-		  ;; tags-buffer is non-nil, which means someone
-		  ;; killed the buffer... so reset it
-		  (doxymacs-set-tags-buffer dir new-buffer)
-		;; Otherwise add to list
-		(setq doxymacs-tags-buffers
-		      (cons (cons dir new-buffer) doxymacs-tags-buffers)))
-	      (message (concat "Loading " xml "..."))
-	      (let ((currbuff (current-buffer)))
-		(if (file-regular-p xml)
-		    ;;It's a regular file, so just grab it.
-		    (progn
-		      (set-buffer new-buffer)
-		      (insert-file-contents xml))
-		  ;; Otherwise, try and grab it as a URL
-		  (progn
-		    (if (doxymacs-url-exists-p xml)
-			(progn
-			  (set-buffer new-buffer)
-			  (url-insert-file-contents xml)
-			  (set-buffer-modified-p nil))
-		      (progn
-			(kill-buffer new-buffer)
-			(set-buffer currbuff)
-			(error (concat
-				  "Tag file " xml " not found."))))))
-		  (set-buffer currbuff))))
+        (if (or (eq tags-buffer nil)
+                (eq (buffer-live-p tags-buffer) nil))
+            (let ((new-buffer (generate-new-buffer "*doxytags")))
+              (if tags-buffer
+                  ;; tags-buffer is non-nil, which means someone
+                  ;; killed the buffer... so reset it
+                  (doxymacs-set-tags-buffer dir new-buffer)
+                ;; Otherwise add to list
+                (setq doxymacs-tags-buffers
+                      (cons (cons dir new-buffer) doxymacs-tags-buffers)))
+              (message (concat "Loading " xml "..."))
+              (let ((currbuff (current-buffer)))
+                (if (file-regular-p xml)
+                    ;;It's a regular file, so just grab it.
+                    (progn
+                      (set-buffer new-buffer)
+                      (insert-file-contents xml))
+                  ;; Otherwise, try and grab it as a URL
+                  (progn
+                    (if (doxymacs-url-exists-p xml)
+                        (progn
+                          (set-buffer new-buffer)
+                          (url-insert-file-contents xml)
+                          (set-buffer-modified-p nil))
+                      (progn
+                        (kill-buffer new-buffer)
+                        (set-buffer currbuff)
+                        (error (concat
+                                "Tag file " xml " not found."))))))
+                (set-buffer currbuff))))
       ;; Couldn't find this file in doxymacs-doxygen-dirs
       (error (concat "File " (buffer-file-name)
-		     " does not match any directories in"
-		     " doxymacs-doxygen-dirs.")))))
+                     " does not match any directories in"
+                     " doxymacs-doxygen-dirs.")))))
 
 (defun doxymacs-add-to-completion-list (symbol desc url)
   "Add a symbol to our completion list, along with its description and URL."
   (let ((check (assoc symbol doxymacs-current-completion-list)))
     (if check
-	;; There is already a symbol with the same name in the list
-	(if (not (assoc desc (cdr check)))
-	    ;; If there is not yet a symbol with this desc, add it
-	    ;; FIXME: what to do if there is already a symbol??
-	    (setcdr check (cons (cons desc url)
-				(cdr check))))
+        ;; There is already a symbol with the same name in the list
+        (if (not (assoc desc (cdr check)))
+            ;; If there is not yet a symbol with this desc, add it
+            ;; FIXME: what to do if there is already a symbol??
+            (setcdr check (cons (cons desc url)
+                                (cdr check))))
       ;; There is not yet a symbol with this name in the list
       (setq doxymacs-current-completion-list
-	    (cons (cons symbol (list (cons desc url)))
-		  doxymacs-current-completion-list)))))
+            (cons (cons symbol (list (cons desc url)))
+                  doxymacs-current-completion-list)))))
 
 (defun doxymacs-fill-completion-list-with-external-parser (f)
   "Use external parser to parse Doxygen XML tags file and get the
 completion list."
   (doxymacs-load-tags f)
   (let ((currbuff (current-buffer))
-	(dir (doxymacs-filename-to-dir f))
-	(comp-list (doxymacs-filename-to-completion-list f))
-	(tags-buffer (doxymacs-filename-to-buffer f)))
+        (dir (doxymacs-filename-to-dir f))
+        (comp-list (doxymacs-filename-to-completion-list f))
+        (tags-buffer (doxymacs-filename-to-buffer f)))
     (set-buffer tags-buffer)
     (goto-char (point-min))
     (doxymacs-set-completion-list dir nil)
     (message (concat
-	      "Executing external process "
-	      doxymacs-external-xml-parser-executable
-	      "..."))
+              "Executing external process "
+              doxymacs-external-xml-parser-executable
+              "..."))
     (let ((status (call-process-region
-		   (point-min) (point-max)
-		   doxymacs-external-xml-parser-executable
-		   t t)))
+                   (point-min) (point-max)
+                   doxymacs-external-xml-parser-executable
+                   t t)))
       (if (eq status 0)
-	  (progn
-	    (goto-char (point-min))
-	    (message "Reading completion list...")
-	    (let ((new-list (read (current-buffer))))
-	      (if comp-list
-		  ;; Replace
-		  (doxymacs-set-completion-list dir new-list)
-		;; Add
-		(setq doxymacs-completion-lists
-		      (cons (cons dir new-list)
-			    doxymacs-completion-lists))))
-	    (message "Done.")
-	    (set-buffer-modified-p nil)
-	    (kill-buffer tags-buffer)
-	    (set-buffer currbuff))
-	(progn
-	  (switch-to-buffer tags-buffer)
-	  (message (concat
-		    "There were problems parsing "
-		    (doxymacs-filename-to-xml f) ".")))))))
+          (progn
+            (goto-char (point-min))
+            (message "Reading completion list...")
+            (let ((new-list (read (current-buffer))))
+              (if comp-list
+                  ;; Replace
+                  (doxymacs-set-completion-list dir new-list)
+                ;; Add
+                (setq doxymacs-completion-lists
+                      (cons (cons dir new-list)
+                            doxymacs-completion-lists))))
+            (message "Done.")
+            (set-buffer-modified-p nil)
+            (kill-buffer tags-buffer)
+            (set-buffer currbuff))
+        (progn
+          (switch-to-buffer tags-buffer)
+          (message (concat
+                    "There were problems parsing "
+                    (doxymacs-filename-to-xml f) ".")))))))
 
 
 (defun doxymacs-xml-progress-callback (amount-done)
@@ -879,56 +879,56 @@ completion list."
 `doxymacs-completion-list' from it using the internal XML file parser."
   (doxymacs-load-tags f)
   (let ((currbuff (current-buffer))
-	(dir (doxymacs-filename-to-dir f))
-	(tags-buffer (doxymacs-filename-to-buffer f)))
+        (dir (doxymacs-filename-to-dir f))
+        (tags-buffer (doxymacs-filename-to-buffer f)))
     (set-buffer tags-buffer)
     (goto-char (point-min))
     (setq doxymacs-current-completion-list nil)
     (let ((xml (read-xml 'doxymacs-xml-progress-callback))) ;Parse the file
       (let* ((compound-list (xml-tag-children xml))
-	     (num-compounds (length compound-list))
-	     (curr-compound-num 0))
-	(if (not (string= (xml-tag-name xml) "tagfile"))
-	    (error (concat "Invalid tag file: " (doxymacs-filename-to-xml f)))
-	  ;; Go through the compounds, adding them and their members to the
-	  ;; completion list.
-	  (while compound-list
-	    (let* ((curr-compound (car compound-list))
-		   (compound-name (cadr (xml-tag-child curr-compound "name")))
-		   (compound-kind (xml-tag-attr curr-compound "kind"))
-		   (compound-url (cadr
-				  (xml-tag-child curr-compound "filename")))
-		   (compound-desc (concat compound-kind " " compound-name)))
-	      ;; Work around apparent bug in Doxygen 1.2.18
-	      (if (not (string-match "\\.html$" compound-url))
-		  (setq compound-url (concat compound-url ".html")))
+             (num-compounds (length compound-list))
+             (curr-compound-num 0))
+        (if (not (string= (xml-tag-name xml) "tagfile"))
+            (error (concat "Invalid tag file: " (doxymacs-filename-to-xml f)))
+          ;; Go through the compounds, adding them and their members to the
+          ;; completion list.
+          (while compound-list
+            (let* ((curr-compound (car compound-list))
+                   (compound-name (cadr (xml-tag-child curr-compound "name")))
+                   (compound-kind (xml-tag-attr curr-compound "kind"))
+                   (compound-url (cadr
+                                  (xml-tag-child curr-compound "filename")))
+                   (compound-desc (concat compound-kind " " compound-name)))
+              ;; Work around apparent bug in Doxygen 1.2.18
+              (if (not (string-match "\\.html$" compound-url))
+                  (setq compound-url (concat compound-url ".html")))
 
-	      ;; Add this compound to our completion list for this directory
-	      (doxymacs-add-to-completion-list compound-name
-					       compound-desc
-					       compound-url)
-	      ;; Add its members
-	      (doxymacs-add-compound-members curr-compound
-					     compound-name
-					     compound-url)
-	      ;; On to the next compound
-	      (message (concat
-			"Building completion table... "
-			(format "%0.1f"
-				(* (/
-				    (float curr-compound-num)
-				    (float num-compounds))
-				   100))
-			"%%"))
-	      (setq curr-compound-num (1+ curr-compound-num))
-	      (setq compound-list (cdr compound-list)))))))
+              ;; Add this compound to our completion list for this directory
+              (doxymacs-add-to-completion-list compound-name
+                                               compound-desc
+                                               compound-url)
+              ;; Add its members
+              (doxymacs-add-compound-members curr-compound
+                                             compound-name
+                                             compound-url)
+              ;; On to the next compound
+              (message (concat
+                        "Building completion table... "
+                        (format "%0.1f"
+                                (* (/
+                                    (float curr-compound-num)
+                                    (float num-compounds))
+                                   100))
+                        "%%"))
+              (setq curr-compound-num (1+ curr-compound-num))
+              (setq compound-list (cdr compound-list)))))))
     (if (doxymacs-filename-to-completion-list f)
-	;; Replace
-	(doxymacs-set-completion-list dir doxymacs-current-completion-list)
+        ;; Replace
+        (doxymacs-set-completion-list dir doxymacs-current-completion-list)
       ;; Add
       (setq doxymacs-completion-lists
-	    (cons (cons dir doxymacs-current-completion-list)
-		  doxymacs-completion-lists)))
+            (cons (cons dir doxymacs-current-completion-list)
+                  doxymacs-completion-lists)))
     (setq doxymacs-current-completion-list nil)
     (message "Done.")
     ;; Don't need the doxytags buffer anymore
@@ -942,20 +942,20 @@ completion list."
     ;; Run through the children looking for ones with the "member" tag
     (while children
       (let* ((curr-child (car children)))
-	(if (string= (xml-tag-name curr-child) "member")
-	    ;; Found a member.  Throw it on the list.
-	    (let* ((member-name (cadr (xml-tag-child curr-child "name")))
-		   (member-anchor (cadr (xml-tag-child curr-child "anchor")))
-		   (member-url (concat compound-url "#" member-anchor))
-		   (member-args (if (cdr (xml-tag-child curr-child "arglist"))
-				    (cadr (xml-tag-child curr-child "arglist"))
-				  ""))
-		   (member-desc (concat compound-name "::"
-					member-name member-args)))
-	      (doxymacs-add-to-completion-list member-name
-					       member-desc
-					       member-url)))
-	(setq children (cdr children))))))
+        (if (string= (xml-tag-name curr-child) "member")
+            ;; Found a member.  Throw it on the list.
+            (let* ((member-name (cadr (xml-tag-child curr-child "name")))
+                   (member-anchor (cadr (xml-tag-child curr-child "anchor")))
+                   (member-url (concat compound-url "#" member-anchor))
+                   (member-args (if (cdr (xml-tag-child curr-child "arglist"))
+                                    (cadr (xml-tag-child curr-child "arglist"))
+                                  ""))
+                   (member-desc (concat compound-name "::"
+                                        member-name member-args)))
+              (doxymacs-add-to-completion-list member-name
+                                               member-desc
+                                               member-url)))
+        (setq children (cdr children))))))
 
 (defun doxymacs-display-url (root url)
   "Displays the given match."
@@ -971,55 +971,55 @@ completion list."
     ;;alg stolen from etag.el
     (save-excursion
       (if (not (memq (char-syntax (preceding-char)) '(?w ?_)))
-	  (while (not (looking-at "\\sw\\|\\s_\\|\\'"))
-	    (forward-char 1)))
+          (while (not (looking-at "\\sw\\|\\s_\\|\\'"))
+            (forward-char 1)))
       (while (looking-at "\\sw\\|\\s_")
-	(forward-char 1))
+        (forward-char 1))
       (if (re-search-backward "\\sw\\|\\s_" nil t)
-	  (regexp-quote
-	   (progn (forward-char 1)
-		  (buffer-substring (point)
-				    (progn (forward-sexp -1)
-					   (while (looking-at "\\s'")
-					     (forward-char 1))
-					   (point)))))
-	nil))))
+          (regexp-quote
+           (progn (forward-char 1)
+                  (buffer-substring (point)
+                                    (progn (forward-sexp -1)
+                                           (while (looking-at "\\s'")
+                                             (forward-char 1))
+                                           (point)))))
+        nil))))
 
 (defun doxymacs-lookup (symbol &optional filename)
   "Look up the symbol under the cursor in Doxygen generated documentation."
   (interactive
    (let* ((f (buffer-file-name))
-	  (completion-list (doxymacs-filename-to-completion-list f)))
+          (completion-list (doxymacs-filename-to-completion-list f)))
      (if (eq f nil)
-	 (error "Current buffer has no file name associated with it.")
+         (error "Current buffer has no file name associated with it.")
        (progn
-	 (save-excursion
-	   (if (eq completion-list nil)
-	       ;;Build our completion list if not already done
-	       (if doxymacs-use-external-xml-parser
-		   (doxymacs-fill-completion-list-with-external-parser f)
-		 (doxymacs-fill-completion-list-with-internal-parser f)))
-	   (let ((symbol (completing-read
-			  "Look up: "
-			  completion-list nil nil
-			  (doxymacs-symbol-near-point)))
-		 (filename f))
-	     (list symbol filename)))))))
+         (save-excursion
+           (if (eq completion-list nil)
+               ;;Build our completion list if not already done
+               (if doxymacs-use-external-xml-parser
+                   (doxymacs-fill-completion-list-with-external-parser f)
+                 (doxymacs-fill-completion-list-with-internal-parser f)))
+           (let ((symbol (completing-read
+                          "Look up: "
+                          completion-list nil nil
+                          (doxymacs-symbol-near-point)))
+                 (filename f))
+             (list symbol filename)))))))
   (let ((url (doxymacs-symbol-completion
-	      symbol
-	      (doxymacs-filename-to-completion-list filename))))
+              symbol
+              (doxymacs-filename-to-completion-list filename))))
     (if url
-	(doxymacs-display-url (doxymacs-filename-to-url filename) url))))
+        (doxymacs-display-url (doxymacs-filename-to-url filename) url))))
 
 (defun doxymacs-display-completions (initial collection &optional pred)
   "Display available completions."
   (let ((matches (all-completions initial collection pred)))
     ;; FIXME - Is this the proper way of doing this? Seems to work, but...
     (set-buffer (format " *Minibuf-%d*"
-			;; Here's a kludge.
-			(if (featurep 'xemacs)
-			    (minibuffer-depth)
-			  (1+ (minibuffer-depth)))))
+                        ;; Here's a kludge.
+                        (if (featurep 'xemacs)
+                            (minibuffer-depth)
+                          (1+ (minibuffer-depth)))))
     (with-output-to-temp-buffer doxymacs-completion-buffer
       (display-completion-list (sort matches 'string-lessp)))))
 
@@ -1035,15 +1035,15 @@ completion list."
            (ding))
           (t
            ;; There is more than one possible completion
-	   (doxymacs-display-completions initial collection pred)
+           (doxymacs-display-completions initial collection pred)
            (let ((completion (completing-read
-			      "Select: "
-			      collection pred nil initial)))
+                              "Select: "
+                              collection pred nil initial)))
              (delete-window (get-buffer-window doxymacs-completion-buffer))
              (if completion
                  ;; If there is a completion, validate it.
                  (doxymacs-validate-symbol-completion
-		  completion collection pred)
+                  completion collection pred)
                ;; Otherwise just return nil
                nil))))))
 
@@ -1072,11 +1072,11 @@ the completion or nil if canceled by the user."
   "Rescan the Doxygen XML tags file in `doxymacs-doxygen-tags'."
   (interactive)
   (let* ((f (buffer-file-name))
-	 (tags-buffer (doxymacs-filename-to-buffer f)))
+         (tags-buffer (doxymacs-filename-to-buffer f)))
     (if (buffer-live-p tags-buffer)
-	(kill-buffer tags-buffer))
+        (kill-buffer tags-buffer))
     (if doxymacs-use-external-xml-parser
-	(doxymacs-fill-completion-list-with-external-parser f)
+        (doxymacs-fill-completion-list-with-external-parser f)
       (doxymacs-fill-completion-list-with-internal-parser f))))
 
 
@@ -1090,10 +1090,10 @@ the completion or nil if canceled by the user."
 ;; should be.
 (if (not (fboundp 'deactivate-mark))
     (defsubst deactivate-mark ()
-      (zmacs-deactivate-region)))	; Is this correct?
+      (zmacs-deactivate-region)))      ; Is this correct?
 ;; Also need a hack for mark-active
 (if (not (boundp 'mark-active))
-    (defvar mark-active nil))		; Is this correct? Probably not.
+    (defvar mark-active nil))          ; Is this correct? Probably not.
 
 ;; Inserting commands with completion
 
@@ -1258,86 +1258,86 @@ the completion or nil if canceled by the user."
 
 where:
 
- - command is the doxygen command.
- - args is a list of prompts to display for each argument to the
-   command.  An element of args could also be a list, the last element of which must be a string to use for the prompt, and other elements may be:
-   - newline to indicate a newline should be appended to the user's input.
-   - word to indicate the argument accepts a single word only.
-   - optional to indicate the argument is optional.")
+- command is the doxygen command.
+- args is a list of prompts to display for each argument to the
+command.  An element of args could also be a list, the last element of which must be a string to use for the prompt, and other elements may be:
+- newline to indicate a newline should be appended to the user's input.
+- word to indicate the argument accepts a single word only.
+- optional to indicate the argument is optional.")
 
 (defun doxymacs-insert-command (cmd)
   "Insert a doxymacs command with completion."
   (interactive (list (completing-read
-		      "Insert doxygen command: "
-		      doxymacs-commands
-		      nil nil nil 'doxymacs-insert-command-history)))
+                      "Insert doxygen command: "
+                      doxymacs-commands
+                      nil nil nil 'doxymacs-insert-command-history)))
   (insert (concat (doxymacs-doxygen-command-char) cmd))
   (dolist (arg-prompt (cdr-safe (assoc cmd doxymacs-commands)))
     (let ((arg (doxymacs-read-arg arg-prompt)))
       (if (or (= (length arg) 0) (string= "\n" arg))
-	  ;; If nothing is entered no point in prompting for the rest of
-	  ;; the args.
-	  (return)
-	(insert (concat " " arg))))))
+          ;; If nothing is entered no point in prompting for the rest of
+          ;; the args.
+          (return)
+        (insert (concat " " arg))))))
 
 (defun doxymacs-read-arg (arg)
   (let* ((newline (and (listp arg) (memq 'newline arg)))
-	 (word (and (listp arg) (memq 'word arg)))
-	 (optional (and (listp arg) (memq 'optional arg)))
-	 (prompt (if (listp arg) (car (last arg)) arg))
-	 (final-prompt (concat prompt
-			       (if optional (concat " (optional)"))
-			       (if word (concat " (word)"))
-			       ": ")))
+         (word (and (listp arg) (memq 'word arg)))
+         (optional (and (listp arg) (memq 'optional arg)))
+         (prompt (if (listp arg) (car (last arg)) arg))
+         (final-prompt (concat prompt
+                               (if optional (concat " (optional)"))
+                               (if word (concat " (word)"))
+                               ": ")))
     (concat
      (cond (word
-	    (read-no-blanks-input final-prompt))
-	   (t
-	    (read-string final-prompt)))
+            (read-no-blanks-input final-prompt))
+           (t
+            (read-string final-prompt)))
      (if newline "\n"))))
 
 
 ;; Default templates
 
 (defconst doxymacs-Fortran-blank-multiline-comment-template
- '("!>" p > n "!!" p > n "!!" > n "!!" > n)
- "Default Fortran-style template for a blank multiline doxygen comment.")
+  '("!>" p > n "!!" p > n "!!" > n "!!" > n)
+  "Default Fortran-style template for a blank multiline doxygen comment.")
 
 (defconst doxymacs-JavaDoc-blank-multiline-comment-template
- '("/**" > n "* " p > n "* " > n "*/" > n)
- "Default JavaDoc-style template for a blank multiline doxygen comment.")
+  '("/**" > n "* " p > n "* " > n "*/" > n)
+  "Default JavaDoc-style template for a blank multiline doxygen comment.")
 
 (defconst doxymacs-Qt-blank-multiline-comment-template
- '("//! " p > n "/*! " > n > n "*/" > n)
- "Default Qt-style template for a blank multiline doxygen comment.")
+  '("//! " p > n "/*! " > n > n "*/" > n)
+  "Default Qt-style template for a blank multiline doxygen comment.")
 
 (defconst doxymacs-C++-blank-multiline-comment-template
- '("///" > n "/// " p > n "///" > n)
- "Default C++-style template for a blank multiline doxygen comment.")
+  '("///" > n "/// " p > n "///" > n)
+  "Default C++-style template for a blank multiline doxygen comment.")
 
 (defconst doxymacs-C++!-blank-multiline-comment-template
- '("//!" > n "//! " p > n "//!" > n)
- "Default C++!-style template for a blank multiline doxygen comment.")
+  '("//!" > n "//! " p > n "//!" > n)
+  "Default C++!-style template for a blank multiline doxygen comment.")
 
 (defconst doxymacs-Fortran-blank-singleline-comment-template
- '("!> " > p)
- "Default Fortran-style template for a blank single line doxygen comment.")
+  '("!> " > p)
+  "Default Fortran-style template for a blank single line doxygen comment.")
 
 (defconst doxymacs-JavaDoc-blank-singleline-comment-template
- '("/// " > p)
- "Default JavaDoc-style template for a blank single line doxygen comment.")
+  '("/// " > p)
+  "Default JavaDoc-style template for a blank single line doxygen comment.")
 
 (defconst doxymacs-Qt-blank-singleline-comment-template
- '("//! " > p)
- "Default Qt-style template for a blank single line doxygen comment.")
+  '("//! " > p)
+  "Default Qt-style template for a blank single line doxygen comment.")
 
 (defconst doxymacs-C++-blank-singleline-comment-template
- '("/// " > p)
- "Default C++-style template for a blank single line doxygen comment.")
+  '("/// " > p)
+  "Default C++-style template for a blank single line doxygen comment.")
 
 (defconst doxymacs-C++!-blank-singleline-comment-template
- '("//! " > p)
- "Default C++!-style template for a blank single line doxygen comment.")
+  '("//! " > p)
+  "Default C++!-style template for a blank single line doxygen comment.")
 
 (defun doxymacs-doxygen-command-char ()
   (cond
@@ -1353,121 +1353,121 @@ where:
   "Return the user's email address"
   (or
    (and (and (fboundp 'user-mail-address) (user-mail-address))
-	(list 'l " <" (user-mail-address) ">"))
+        (list 'l " <" (user-mail-address) ">"))
    (and (and (boundp 'user-mail-address) user-mail-address)
-	(list 'l " <" user-mail-address ">"))))
+        (list 'l " <" user-mail-address ">"))))
 
 (defconst doxymacs-Fortran-file-comment-template
- '("!> " (doxymacs-doxygen-command-char) "file   "
-   (if (buffer-file-name)
-       (file-name-nondirectory (buffer-file-name))
-     "") > p > n
-   "!! " (doxymacs-doxygen-command-char) "author " (user-full-name)
-   (doxymacs-user-mail-address)
-   > n
-   "!! " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
-   "!! " > n
-   "!! " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
-   "!! " p > n)
-   ;; "!<" > n)
- "Default Fortran-style template for file documentation.")
+  '("!> " (doxymacs-doxygen-command-char) "file   "
+    (if (buffer-file-name)
+        (file-name-nondirectory (buffer-file-name))
+      "") > p > n
+    "!! " (doxymacs-doxygen-command-char) "author " (user-full-name)
+    (doxymacs-user-mail-address)
+    > n
+    "!! " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
+    "!! " > n
+    "!! " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
+    "!! " p > n)
+  ;; "!<" > n)
+  "Default Fortran-style template for file documentation.")
 
 (defconst doxymacs-JavaDoc-file-comment-template
- '("/**" > n
-   " * " (doxymacs-doxygen-command-char) "file   "
-   (if (buffer-file-name)
-       (file-name-nondirectory (buffer-file-name))
-     "") > n
-   " * " (doxymacs-doxygen-command-char) "author " (user-full-name)
-   (doxymacs-user-mail-address)
-   > n
-   " * " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
-   " * " > n
-   " * " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
-   " * " > n
-   " * " p > n
-   " */" > n)
- "Default JavaDoc-style template for file documentation.")
+  '("/**" > n
+    " * " (doxymacs-doxygen-command-char) "file   "
+    (if (buffer-file-name)
+        (file-name-nondirectory (buffer-file-name))
+      "") > n
+    " * " (doxymacs-doxygen-command-char) "author " (user-full-name)
+    (doxymacs-user-mail-address)
+    > n
+    " * " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
+    " * " > n
+    " * " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
+    " * " > n
+    " * " p > n
+    " */" > n)
+  "Default JavaDoc-style template for file documentation.")
 
 (defconst doxymacs-Qt-file-comment-template
- '("/*!" > n
-   " " (doxymacs-doxygen-command-char) "file   "
-   (if (buffer-file-name)
-       (file-name-nondirectory (buffer-file-name))
-     "") > n
-   " " (doxymacs-doxygen-command-char) "author " (user-full-name)
-   (doxymacs-user-mail-address)
-   > n
-   " " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
-   " " > n
-   " " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
-   " " > n
-   " " p > n
-   "*/" > n)
- "Default Qt-style template for file documentation.")
+  '("/*!" > n
+    " " (doxymacs-doxygen-command-char) "file   "
+    (if (buffer-file-name)
+        (file-name-nondirectory (buffer-file-name))
+      "") > n
+    " " (doxymacs-doxygen-command-char) "author " (user-full-name)
+    (doxymacs-user-mail-address)
+    > n
+    " " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
+    " " > n
+    " " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
+    " " > n
+    " " p > n
+    "*/" > n)
+  "Default Qt-style template for file documentation.")
 
 (defconst doxymacs-C++-file-comment-template
- '("///" > n
-   "/// " (doxymacs-doxygen-command-char) "file   "
-   (if (buffer-file-name)
-       (file-name-nondirectory (buffer-file-name))
-     "") > n
-   "/// " (doxymacs-doxygen-command-char) "author " (user-full-name)
-   (doxymacs-user-mail-address)
-   > n
-   "/// " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
-   "/// " > n
-   "/// " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
-   "/// " > n
-   "/// " p > n
-   "///" > n)
- "Default C++-style template for file documentation.")
+  '("///" > n
+    "/// " (doxymacs-doxygen-command-char) "file   "
+    (if (buffer-file-name)
+        (file-name-nondirectory (buffer-file-name))
+      "") > n
+    "/// " (doxymacs-doxygen-command-char) "author " (user-full-name)
+    (doxymacs-user-mail-address)
+    > n
+    "/// " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
+    "/// " > n
+    "/// " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
+    "/// " > n
+    "/// " p > n
+    "///" > n)
+  "Default C++-style template for file documentation.")
 
 (defconst doxymacs-C++!-file-comment-template
- '("//!" > n
-   "//! " (doxymacs-doxygen-command-char) "file   "
-   (if (buffer-file-name)
-       (file-name-nondirectory (buffer-file-name))
-     "") > n
-   "//! " (doxymacs-doxygen-command-char) "author " (user-full-name)
-   (doxymacs-user-mail-address)
-   > n
-   "//! " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
-   "//! " > n
-   "//! " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
-   "//! " > n
-   "//! " p > n
-   "//!" > n)
- "Default C++!-style template for file documentation.")
+  '("//!" > n
+    "//! " (doxymacs-doxygen-command-char) "file   "
+    (if (buffer-file-name)
+        (file-name-nondirectory (buffer-file-name))
+      "") > n
+    "//! " (doxymacs-doxygen-command-char) "author " (user-full-name)
+    (doxymacs-user-mail-address)
+    > n
+    "//! " (doxymacs-doxygen-command-char) "date   " (current-time-string) > n
+    "//! " > n
+    "//! " (doxymacs-doxygen-command-char) "brief  " (p "Brief description of this file: ") > n
+    "//! " > n
+    "//! " p > n
+    "//!" > n)
+  "Default C++!-style template for file documentation.")
 
 
 (defun doxymacs-parm-tempo-element (parms)
   "Inserts tempo elements for the given parms in the given style."
   (if parms
       (let ((prompt (concat "Parameter " (car parms) ": ")))
-	(cond
-	 ((string= doxymacs-doxygen-style "JavaDoc")
-	  (list 'l " * " (doxymacs-doxygen-command-char)
-		"param " (car parms) " " (list 'p prompt) '> 'n
-		(doxymacs-parm-tempo-element (cdr parms))))
-	 ((string= doxymacs-doxygen-style "Qt")
-	  (list 'l " " (doxymacs-doxygen-command-char)
-		"param " (car parms) " " (list 'p prompt) '> 'n
-		(doxymacs-parm-tempo-element (cdr parms))))
-	 ((string= doxymacs-doxygen-style "C++")
-	  (list 'l "/// " (doxymacs-doxygen-command-char)
-		"param " (car parms) " " (list 'p prompt) '> 'n
-		(doxymacs-parm-tempo-element (cdr parms))))
-	 ((string= doxymacs-doxygen-style "C++!")
-	  (list 'l "//! " (doxymacs-doxygen-command-char)
-		"param " (car parms) " " (list 'p prompt) '> 'n
-		(doxymacs-parm-tempo-element (cdr parms))))
-	 ((string= doxymacs-doxygen-style "Fortran")
-	  (list 'l "!! " (doxymacs-doxygen-command-char)
-		"param " (car parms) " " (list 'p prompt) '> 'n
-		(doxymacs-parm-tempo-element (cdr parms))))
-	 (t
-	  (doxymacs-invalid-style))))
+        (cond
+         ((string= doxymacs-doxygen-style "JavaDoc")
+          (list 'l " * " (doxymacs-doxygen-command-char)
+                "param " (car parms) " " (list 'p prompt) '> 'n
+                (doxymacs-parm-tempo-element (cdr parms))))
+         ((string= doxymacs-doxygen-style "Qt")
+          (list 'l " " (doxymacs-doxygen-command-char)
+                "param " (car parms) " " (list 'p prompt) '> 'n
+                (doxymacs-parm-tempo-element (cdr parms))))
+         ((string= doxymacs-doxygen-style "C++")
+          (list 'l "/// " (doxymacs-doxygen-command-char)
+                "param " (car parms) " " (list 'p prompt) '> 'n
+                (doxymacs-parm-tempo-element (cdr parms))))
+         ((string= doxymacs-doxygen-style "C++!")
+          (list 'l "//! " (doxymacs-doxygen-command-char)
+                "param " (car parms) " " (list 'p prompt) '> 'n
+                (doxymacs-parm-tempo-element (cdr parms))))
+         ((string= doxymacs-doxygen-style "Fortran")
+          (list 'l "!! " (doxymacs-doxygen-command-char)
+                "param " (car parms) " " (list 'p prompt) '> 'n
+                (doxymacs-parm-tempo-element (cdr parms))))
+         (t
+          (doxymacs-invalid-style))))
     nil))
 
 (defun doxymacs-throws-tempo-element (throws)
@@ -1500,134 +1500,134 @@ where:
     nil))
 
 (defconst doxymacs-Fortran-function-comment-template
- '((let ((next-func (doxymacs-find-next-func)))
-     (if next-func
-	 (list
-	  'l
-	  "!> " 'p '> 'n
-	  (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
-          (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
-	  (unless (string-match
-                   (regexp-quote (cdr (assoc 'return next-func)))
-                   doxymacs-void-types)
-	    '(l "!! " > n "!! " (doxymacs-doxygen-command-char)
-		"return " (p "Returns: ") > n)))
-	  ;; "!<" '>)
-       (progn
-	 (error "Can't find next function declaration.")
-	 nil))))
- "Default Fortran-style template for function documentation.")
+  '((let ((next-func (doxymacs-find-next-func)))
+      (if next-func
+          (list
+           'l
+           "!> " 'p '> 'n
+           (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
+           (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
+           (unless (string-match
+                    (regexp-quote (cdr (assoc 'return next-func)))
+                    doxymacs-void-types)
+             '(l "!! " > n "!! " (doxymacs-doxygen-command-char)
+                 "return " (p "Returns: ") > n)))
+        ;; "!<" '>)
+        (progn
+          (error "Can't find next function declaration.")
+          nil))))
+  "Default Fortran-style template for function documentation.")
 
 
 (defconst doxymacs-JavaDoc-function-comment-template
- '((let ((next-func (doxymacs-find-next-func)))
-     (if next-func
-	 (list
-	  'l
-	  "/** " '> 'n
-	  " * " 'p '> 'n
-	  " *" '> 'n
-	  (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
-          (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
-	  (unless (string-match
-                   (regexp-quote (cdr (assoc 'return next-func)))
-                   doxymacs-void-types)
-	    '(l " *" > n " * " (doxymacs-doxygen-command-char)
-		"return " (p "Returns: ") > n))
-	  " */" '>)
-       (progn
-	 (error "Can't find next function declaration.")
-	 nil))))
- "Default JavaDoc-style template for function documentation.")
+  '((let ((next-func (doxymacs-find-next-func)))
+      (if next-func
+          (list
+           'l
+           "/** " '> 'n
+           " * " 'p '> 'n
+           " *" '> 'n
+           (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
+           (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
+           (unless (string-match
+                    (regexp-quote (cdr (assoc 'return next-func)))
+                    doxymacs-void-types)
+             '(l " *" > n " * " (doxymacs-doxygen-command-char)
+                 "return " (p "Returns: ") > n))
+           " */" '>)
+        (progn
+          (error "Can't find next function declaration.")
+          nil))))
+  "Default JavaDoc-style template for function documentation.")
 
 (defconst doxymacs-Qt-function-comment-template
- '((let ((next-func (doxymacs-find-next-func)))
-     (if next-func
-	 (list
-	  'l
-	  "//! " 'p '> 'n
-	  "/*! " '> 'n
-	  " " '> 'n
-	  (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
-          (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
-	  (unless (string-match
-                   (regexp-quote (cdr (assoc 'return next-func)))
-                   doxymacs-void-types)
-	    '(l " " > n "  " (doxymacs-doxygen-command-char)
-		"return " (p "Returns: ") > n))
-	  " */" '>)
-       (progn
-	 (error "Can't find next function declaraton.")
-	 nil))))
- "Default Qt-style template for function documentation.")
+  '((let ((next-func (doxymacs-find-next-func)))
+      (if next-func
+          (list
+           'l
+           "//! " 'p '> 'n
+           "/*! " '> 'n
+           " " '> 'n
+           (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
+           (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
+           (unless (string-match
+                    (regexp-quote (cdr (assoc 'return next-func)))
+                    doxymacs-void-types)
+             '(l " " > n "  " (doxymacs-doxygen-command-char)
+                 "return " (p "Returns: ") > n))
+           " */" '>)
+        (progn
+          (error "Can't find next function declaraton.")
+          nil))))
+  "Default Qt-style template for function documentation.")
 
 (defconst doxymacs-C++-function-comment-template
- '((let ((next-func (doxymacs-find-next-func)))
-     (if next-func
-	 (list
-	  'l
-	  "/// " 'p '> 'n
-	  "///" '> 'n
-	  (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
-          (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
-	  (unless (string-match
-                   (regexp-quote (cdr (assoc 'return next-func)))
-                   doxymacs-void-types)
-	    '(l "///" > n "/// " (doxymacs-doxygen-command-char)
-		"return " (p "Returns: ") > n))
-	  "///" '>)
-       (progn
-	 (error "Can't find next function declaraton.")
-	 nil))))
- "Default C++-style template for function documentation.")
+  '((let ((next-func (doxymacs-find-next-func)))
+      (if next-func
+          (list
+           'l
+           "/// " 'p '> 'n
+           "///" '> 'n
+           (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
+           (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
+           (unless (string-match
+                    (regexp-quote (cdr (assoc 'return next-func)))
+                    doxymacs-void-types)
+             '(l "///" > n "/// " (doxymacs-doxygen-command-char)
+                 "return " (p "Returns: ") > n))
+           "///" '>)
+        (progn
+          (error "Can't find next function declaraton.")
+          nil))))
+  "Default C++-style template for function documentation.")
 
 (defconst doxymacs-C++!-function-comment-template
- '((let ((next-func (doxymacs-find-next-func)))
-     (if next-func
-	 (list
-	  'l
-	  "//! " 'p '> 'n
-	  "//!" '> 'n
-	  (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
-          (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
-	  (unless (string-match
-                   (regexp-quote (cdr (assoc 'return next-func)))
-                   doxymacs-void-types)
-	    '(l "//!" > n "//! " (doxymacs-doxygen-command-char)
-		"return " (p "Returns: ") > n))
-	  "//!" '>)
-       (progn
-	 (error "Can't find next function declaraton.")
-	 nil))))
- "Default C++!-style template for function documentation.")
+  '((let ((next-func (doxymacs-find-next-func)))
+      (if next-func
+          (list
+           'l
+           "//! " 'p '> 'n
+           "//!" '> 'n
+           (doxymacs-parm-tempo-element (cdr (assoc 'args next-func)))
+           (doxymacs-throws-tempo-element (cdr (assoc 'throws next-func)))
+           (unless (string-match
+                    (regexp-quote (cdr (assoc 'return next-func)))
+                    doxymacs-void-types)
+             '(l "//!" > n "//! " (doxymacs-doxygen-command-char)
+                 "return " (p "Returns: ") > n))
+           "//!" '>)
+        (progn
+          (error "Can't find next function declaraton.")
+          nil))))
+  "Default C++!-style template for function documentation.")
 
 (defun doxymacs-invalid-style ()
   "Warn the user that he has set `doxymacs-doxygen-style' to an invalid
 style."
   (error (concat
-	  "Invalid `doxymacs-doxygen-style': "
-	  doxymacs-doxygen-style
-	  ": must be one of \"JavaDoc\", \"Qt\", \"C++\", \"C++!\", or \"Fortran\".")))
+          "Invalid `doxymacs-doxygen-style': "
+          doxymacs-doxygen-style
+          ": must be one of \"JavaDoc\", \"Qt\", \"C++\", \"C++!\", or \"Fortran\".")))
 
 ;; This should make it easier to add new templates and cut down
 ;; on copy-and-paste programming.
 (defun doxymacs-call-template (template-name)
   "Insert the given template."
   (let* ((user-template-name (concat "doxymacs-" template-name "-template"))
-	 (user-template (car (read-from-string user-template-name)))
-	 (default-template-name (concat "doxymacs-"
-					doxymacs-doxygen-style "-"
-					template-name "-template"))
-	 (default-template (car (read-from-string default-template-name))))
+         (user-template (car (read-from-string user-template-name)))
+         (default-template-name (concat "doxymacs-"
+                                        doxymacs-doxygen-style "-"
+                                        template-name "-template"))
+         (default-template (car (read-from-string default-template-name))))
     (cond
-     ((and (boundp user-template)	; Make sure it is a non-nil list
-	   (listp (eval user-template))
-	   (eval user-template))
+     ((and (boundp user-template)      ; Make sure it is a non-nil list
+           (listp (eval user-template))
+           (eval user-template))
       ;; Use the user's template
       (tempo-insert-template user-template tempo-insert-region))
      ((and (boundp default-template)
-	   (listp (eval default-template))
-	   (eval default-template))
+           (listp (eval default-template))
+           (eval default-template))
       ;; Use the default template, based on the current style
       (tempo-insert-template default-template tempo-insert-region))
      (t
@@ -1663,12 +1663,12 @@ current point."
     (save-excursion
       (beginning-of-line)
       (let ((eol (save-excursion (end-of-line) (point))))
-	(and skip
-	     (re-search-forward skip eol t)
-	     (setq eol (match-beginning 0)))
-	(goto-char eol)
-	(skip-chars-backward " \t")
-	(max comment-column (1+ (current-column))))))
+        (and skip
+             (re-search-forward skip eol t)
+             (setq eol (match-beginning 0)))
+        (goto-char eol)
+        (skip-chars-backward " \t")
+        (max comment-column (1+ (current-column))))))
   "Function to compute desired indentation for a comment.
 This function is called with skip and with point at the beginning of
 the comment's starting delimiter.")
@@ -1678,111 +1678,111 @@ the comment's starting delimiter.")
 the column given by `comment-column' (much like \\[indent-for-comment])."
   (interactive "*")
   (let* ((empty (save-excursion (beginning-of-line)
-				(looking-at "[ \t]*$")))
-	 (starter (or doxymacs-member-comment-start
-		      (cond
-		       ((string= doxymacs-doxygen-style "JavaDoc")
-			"/**< ")
-		       ((string= doxymacs-doxygen-style "Qt")
-			"/*!< ")
-		       ((string= doxymacs-doxygen-style "C++")
-			"///< ")
-		       ((string= doxymacs-doxygen-style "C++!")
-			"//!< ")
-		       ((string= doxymacs-doxygen-style "Fortran")
-			"!< ")
-		       (t
-			(doxymacs-invalid-style)))))
-	 (skip (concat (regexp-quote starter) "*"))
-	 (ender (or doxymacs-member-comment-end
-		    (cond
-		       ((string= doxymacs-doxygen-style "JavaDoc")
-			" */")
-		       ((string= doxymacs-doxygen-style "Qt")
-			" */")
-		       ((string= doxymacs-doxygen-style "C++")
-			"")
-		       ((string= doxymacs-doxygen-style "C++!")
-			"")
-		       ((string= doxymacs-doxygen-style "Fortran")
-			"")
-		       (t
-			(doxymacs-invalid-style))))))
+                                (looking-at "[ \t]*$")))
+         (starter (or doxymacs-member-comment-start
+                      (cond
+                       ((string= doxymacs-doxygen-style "JavaDoc")
+                        "/**< ")
+                       ((string= doxymacs-doxygen-style "Qt")
+                        "/*!< ")
+                       ((string= doxymacs-doxygen-style "C++")
+                        "///< ")
+                       ((string= doxymacs-doxygen-style "C++!")
+                        "//!< ")
+                       ((string= doxymacs-doxygen-style "Fortran")
+                        "!< ")
+                       (t
+                        (doxymacs-invalid-style)))))
+         (skip (concat (regexp-quote starter) "*"))
+         (ender (or doxymacs-member-comment-end
+                    (cond
+                     ((string= doxymacs-doxygen-style "JavaDoc")
+                      " */")
+                     ((string= doxymacs-doxygen-style "Qt")
+                      " */")
+                     ((string= doxymacs-doxygen-style "C++")
+                      "")
+                     ((string= doxymacs-doxygen-style "C++!")
+                      "")
+                     ((string= doxymacs-doxygen-style "Fortran")
+                      "")
+                     (t
+                      (doxymacs-invalid-style))))))
     (if empty
-	;; Insert a blank single-line comment on empty lines
-	(doxymacs-insert-blank-singleline-comment)
+        ;; Insert a blank single-line comment on empty lines
+        (doxymacs-insert-blank-singleline-comment)
       (if (null starter)
-	  (error "No Doxygen member comment syntax defined")
-	(let* ((eolpos (save-excursion (end-of-line) (point)))
-	       cpos indent begpos)
-	  (beginning-of-line)
-	  (if (re-search-forward skip eolpos 'move)
-	      (progn (setq cpos (point-marker))
-		     ;; Find the start of the comment delimiter.
-		     ;; If there were paren-pairs in skip,
-		     ;; position at the end of the first pair.
-		     (if (match-end 1)
-			 (goto-char (match-end 1))
-		       ;; If skip matched a string with
-		       ;; internal whitespace (not final whitespace) then
-		       ;; the delimiter start at the end of that
-		       ;; whitespace.  Otherwise, it starts at the
-		       ;; beginning of what was matched.
-		       (skip-syntax-backward " " (match-beginning 0))
-		       (skip-syntax-backward "^ " (match-beginning 0)))))
-	  (setq begpos (point))
-	  ;; Compute desired indent.
-	  (cond
-	   ((= (current-column) 0)
-	    (goto-char begpos))
-	   ((= (current-column)
-	       (setq indent (funcall doxymacs-comment-indent-function skip)))
-	    (goto-char begpos))
-	   (t
-	    ;; If that's different from current, change it.
-	    (skip-chars-backward " \t")
-	    (delete-region (point) begpos)
-	    (indent-to indent)))
-	  ;; An existing comment?
-	  (if cpos
-	      (progn (goto-char cpos)
-		     (set-marker cpos nil))
-	    ;; No, insert one.
-	    (insert starter)
-	    (save-excursion
-	      (insert ender))))))))
+          (error "No Doxygen member comment syntax defined")
+        (let* ((eolpos (save-excursion (end-of-line) (point)))
+               cpos indent begpos)
+          (beginning-of-line)
+          (if (re-search-forward skip eolpos 'move)
+              (progn (setq cpos (point-marker))
+                     ;; Find the start of the comment delimiter.
+                     ;; If there were paren-pairs in skip,
+                     ;; position at the end of the first pair.
+                     (if (match-end 1)
+                         (goto-char (match-end 1))
+                       ;; If skip matched a string with
+                       ;; internal whitespace (not final whitespace) then
+                       ;; the delimiter start at the end of that
+                       ;; whitespace.  Otherwise, it starts at the
+                       ;; beginning of what was matched.
+                       (skip-syntax-backward " " (match-beginning 0))
+                       (skip-syntax-backward "^ " (match-beginning 0)))))
+          (setq begpos (point))
+          ;; Compute desired indent.
+          (cond
+           ((= (current-column) 0)
+            (goto-char begpos))
+           ((= (current-column)
+               (setq indent (funcall doxymacs-comment-indent-function skip)))
+            (goto-char begpos))
+           (t
+            ;; If that's different from current, change it.
+            (skip-chars-backward " \t")
+            (delete-region (point) begpos)
+            (indent-to indent)))
+          ;; An existing comment?
+          (if cpos
+              (progn (goto-char cpos)
+                     (set-marker cpos nil))
+            ;; No, insert one.
+            (insert starter)
+            (save-excursion
+              (insert ender))))))))
 
 (defun doxymacs-insert-grouping-comments (start end)
   "Inserts doxygen grouping comments around the current region."
   (interactive "*r")
   (let* ((starter  (or doxymacs-group-comment-start
-		      (cond
-		       ((string= doxymacs-doxygen-style "JavaDoc")
-			"//@{")
-		       ((string= doxymacs-doxygen-style "Qt")
-			"/*@{*/")
-		       ((string= doxymacs-doxygen-style "C++")
-			"/// @{")
-		       ((string= doxymacs-doxygen-style "C++!")
-			"//! @{")
-		       ((string= doxymacs-doxygen-style "Fortran")
-			"!> @{")
-		       (t
-			(doxymacs-invalid-style)))))
-	 (ender (or doxymacs-group-comment-end
-		    (cond
-		       ((string= doxymacs-doxygen-style "JavaDoc")
-			"//@}")
-		       ((string= doxymacs-doxygen-style "Qt")
-			"/*@}*/")
-		       ((string= doxymacs-doxygen-style "C++")
-			"/// @}")
-		       ((string= doxymacs-doxygen-style "C++!")
-			"//! @}")
-		       ((string= doxymacs-doxygen-style "Fortran")
-			"!! @}")
-		       (t
-			(doxymacs-invalid-style))))))
+                       (cond
+                        ((string= doxymacs-doxygen-style "JavaDoc")
+                         "//@{")
+                        ((string= doxymacs-doxygen-style "Qt")
+                         "/*@{*/")
+                        ((string= doxymacs-doxygen-style "C++")
+                         "/// @{")
+                        ((string= doxymacs-doxygen-style "C++!")
+                         "//! @{")
+                        ((string= doxymacs-doxygen-style "Fortran")
+                         "!> @{")
+                        (t
+                         (doxymacs-invalid-style)))))
+         (ender (or doxymacs-group-comment-end
+                    (cond
+                     ((string= doxymacs-doxygen-style "JavaDoc")
+                      "//@}")
+                     ((string= doxymacs-doxygen-style "Qt")
+                      "/*@}*/")
+                     ((string= doxymacs-doxygen-style "C++")
+                      "/// @}")
+                     ((string= doxymacs-doxygen-style "C++!")
+                      "//! @}")
+                     ((string= doxymacs-doxygen-style "Fortran")
+                      "!! @}")
+                     (t
+                      (doxymacs-invalid-style))))))
     (save-excursion
       (goto-char end)
       (end-of-line)
@@ -1957,52 +1957,52 @@ The argument list is a list of strings."
   (interactive)
   (save-excursion
     (if (re-search-forward
-	 (concat
-	  ;; return type
-	  "\\(\\(const[ \t\n]+\\)?[a-zA-Z0-9_]+[ \t\n*&]+\\)?"
+         (concat
+          ;; return type
+          "\\(\\(const[ \t\n]+\\)?[a-zA-Z0-9_]+[ \t\n*&]+\\)?"
 
-	  ;; name
-	  "\\(\\([a-zA-Z0-9_~:<,>*&]\\|\\([ \t\n]+::[ \t\n]+\\)\\)+"
-	  "\\(o?perator[ \t\n]*.[^(]*\\)?\\)[ \t\n]*("
-	  ) nil t)
+          ;; name
+          "\\(\\([a-zA-Z0-9_~:<,>*&]\\|\\([ \t\n]+::[ \t\n]+\\)\\)+"
+          "\\(o?perator[ \t\n]*.[^(]*\\)?\\)[ \t\n]*("
+          ) nil t)
 
-	(let* ((func (buffer-substring (match-beginning 3) (match-end 3)))
-	       (args (buffer-substring (point) (progn
-                                                (backward-char 1)
-                                                (forward-list)
-                                                (backward-char 1)
-                                                (point))))
-	       (ret (cond
-		     ;; Return type specified
-		     ((match-beginning 1)
-		      (buffer-substring (match-beginning 1) (match-end 1)))
-		     ;;Constructor/destructor
-		     ((string-match
-		       "^\\([a-zA-Z0-9_<,>:*&]+\\)[ \t\n]*::[ \t\n]*~?\\1$"
-		       func) "void")
-		     ;;Constructor in class decl.
-		     ((save-match-data
-			(re-search-backward
-			 (concat
-			  "class[ \t\n]+" (regexp-quote func) "[ \t\n]*{")
-			 nil t))
-		      "void")
-		     ;;Destructor in class decl.
-		     ((save-match-data
-			(and (string-match "^~\\([a-zA-Z0-9_]+\\)$" func)
-			     (save-match-data
-			       (re-search-backward
-				(concat
-				 "class[ \t\n]+" (regexp-quote
-						  (match-string 1 func))
-				 "[ \t\n]*{") nil t))))
-		      "void")
-		     ;;Default
-		     (t "int"))))
-	  (list (cons 'func func)
-		(cons 'args (doxymacs-extract-args-list args))
+        (let* ((func (buffer-substring (match-beginning 3) (match-end 3)))
+               (args (buffer-substring (point) (progn
+                                                 (backward-char 1)
+                                                 (forward-list)
+                                                 (backward-char 1)
+                                                 (point))))
+               (ret (cond
+                     ;; Return type specified
+                     ((match-beginning 1)
+                      (buffer-substring (match-beginning 1) (match-end 1)))
+                     ;;Constructor/destructor
+                     ((string-match
+                       "^\\([a-zA-Z0-9_<,>:*&]+\\)[ \t\n]*::[ \t\n]*~?\\1$"
+                       func) "void")
+                     ;;Constructor in class decl.
+                     ((save-match-data
+                        (re-search-backward
+                         (concat
+                          "class[ \t\n]+" (regexp-quote func) "[ \t\n]*{")
+                         nil t))
+                      "void")
+                     ;;Destructor in class decl.
+                     ((save-match-data
+                        (and (string-match "^~\\([a-zA-Z0-9_]+\\)$" func)
+                             (save-match-data
+                               (re-search-backward
+                                (concat
+                                 "class[ \t\n]+" (regexp-quote
+                                                  (match-string 1 func))
+                                 "[ \t\n]*{") nil t))))
+                      "void")
+                     ;;Default
+                     (t "int"))))
+          (list (cons 'func func)
+                (cons 'args (doxymacs-extract-args-list args))
                 (cons 'throws (doxymacs--get-throws))
-		(cons 'return (doxymacs-core-string ret))))
-    nil)))
+                (cons 'return (doxymacs-core-string ret))))
+      nil)))
 
 ;;; doxymacs.el ends here

--- a/lisp/xml-parse.el
+++ b/lisp/xml-parse.el
@@ -133,10 +133,10 @@ Point is left at the end of the XML structure read."
 (defsubst xml-tag-name (tag)
   "Return the name of an xml-parse'd XML TAG."
   (cond ((xml-tag-text-p tag)
-	 (car tag))
-	((xml-tag-with-attributes-p tag)
-	 (caar tag))
-	(t (car tag))))
+         (car tag))
+        ((xml-tag-with-attributes-p tag)
+         (caar tag))
+        (t (car tag))))
 
 (defun xml-tag-text-p (tag)
   "Is the given TAG really just a text entry?"
@@ -165,22 +165,22 @@ Point is left at the end of the XML structure read."
   (catch 'found
     (let ((children (xml-tag-children tag)))
       (while children
-	(if (string= name (xml-tag-name (car children)))
-	    (throw 'found (car children)))
-	(setq children (cdr children))))))
+        (if (string= name (xml-tag-name (car children)))
+            (throw 'found (car children)))
+        (setq children (cdr children))))))
 
 ;;;###autoload
 (defun insert-xml (data &optional add-newlines public system depth ret-depth)
   "Insert DATA, a recursive Lisp structure, at point as XML.
 DATA has the form:
 
-  ENTRY       ::=  (TAG CHILD*)
-  CHILD       ::=  STRING | ENTRY
-  TAG         ::=  TAG_NAME | (TAG_NAME ATTR+)
-  ATTR        ::=  (ATTR_NAME . ATTR_VALUE)
-  TAG_NAME    ::=  STRING
-  ATTR_NAME   ::=  STRING
-  ATTR_VALUE  ::=  STRING
+ENTRY       ::=  (TAG CHILD*)
+CHILD       ::=  STRING | ENTRY
+TAG         ::=  TAG_NAME | (TAG_NAME ATTR+)
+ATTR        ::=  (ATTR_NAME . ATTR_VALUE)
+TAG_NAME    ::=  STRING
+ATTR_NAME   ::=  STRING
+ATTR_VALUE  ::=  STRING
 
 If ADD-NEWLINES is non-nil, newlines and indentation will be added to
 make the data user-friendly.
@@ -193,37 +193,37 @@ indentation."
   (when (and (not depth) public system)
     (insert "<?xml version=\"1.0\"?>\n")
     (insert "<!DOCTYPE " (if (stringp (car data))
-			     (car data)
-			   (caar data))
-	    " PUBLIC \"" public "\"\n  \"" system "\">\n"))
+                             (car data)
+                           (caar data))
+            " PUBLIC \"" public "\"\n  \"" system "\">\n"))
   (if (stringp data)
       (insert data)
     (let ((node (car data)) (add-nl t))
       (and depth (bolp)
-	   (insert (make-string (* depth 2) ? )))
+           (insert (make-string (* depth 2) ? )))
       (if (stringp node)
-	  (insert "<" node)
-	(setq node (caar data))
-	(insert "<" node)
-	(let ((attrs (cdar data)))
-	  (while attrs
-	    (insert " " (caar attrs) "=\"" (cdar attrs) "\"")
-	    (setq attrs (cdr attrs)))))
+          (insert "<" node)
+        (setq node (caar data))
+        (insert "<" node)
+        (let ((attrs (cdar data)))
+          (while attrs
+            (insert " " (caar attrs) "=\"" (cdar attrs) "\"")
+            (setq attrs (cdr attrs)))))
       (if (null (cdr data))
-	  (insert "/>")
-	(insert ">")
-	(setq data (cdr data))
-	(while data
-	  (and add-newlines add-nl
-	       (not (stringp (car data)))
-	       (insert ?\n))
-	  (setq add-nl (insert-xml (car data) add-newlines
-				   nil nil (1+ (or depth 0)))
-		data (cdr data)))
-	(when add-nl
-	  (and add-newlines (insert ?\n))
-	  (and depth (insert (make-string (* depth 2) ? ))))
-	(insert "</" node ">"))
+          (insert "/>")
+        (insert ">")
+        (setq data (cdr data))
+        (while data
+          (and add-newlines add-nl
+               (not (stringp (car data)))
+               (insert ?\n))
+          (setq add-nl (insert-xml (car data) add-newlines
+                                   nil nil (1+ (or depth 0)))
+                data (cdr data)))
+        (when add-nl
+          (and add-newlines (insert ?\n))
+          (and depth (insert (make-string (* depth 2) ? ))))
+        (insert "</" node ">"))
       t)))
 
 ;;;###autoload
@@ -247,23 +247,23 @@ Note that this only works if the opening tag starts at column 0."
 (defun xml-parse-profile ()
   (interactive)
   (let ((elp-function-list
-	 '(buffer-substring-no-properties
-	   char-after
-	   char-before
-	   forward-char
-	   looking-at
-	   match-string-no-properties
-	   match-beginning
-	   match-end
-	   point
-	   re-search-forward
-	   read-xml
-	   xml-parse-read
-	   search-forward
-	   string=
-	   stringp
-	   substring
-	   xml-parse-concat)))
+         '(buffer-substring-no-properties
+           char-after
+           char-before
+           forward-char
+           looking-at
+           match-string-no-properties
+           match-beginning
+           match-end
+           point
+           re-search-forward
+           read-xml
+           xml-parse-read
+           search-forward
+           string=
+           stringp
+           substring
+           xml-parse-concat)))
     (elp-instrument-list)))
 
 (defsubst xml-parse-skip-tag ()
@@ -275,24 +275,24 @@ Note that this only works if the opening tag starts at column 0."
    (t					; must be <!...>
     (re-search-forward "[[>]")
     (if (eq (char-before) ?\[)
-	(let ((depth 1))
-	  (while (and (> depth 0)
-		      (if (re-search-forward "[][]")
-			  t
-			(error "Pos %d: Unclosed open bracket in <! tag")))
-	    (if (eq (char-before) ?\[)
-		(setq depth (1+ depth))
-	      (setq depth (1- depth))))
-	  (search-forward ">"))))))
+        (let ((depth 1))
+          (while (and (> depth 0)
+                      (if (re-search-forward "[][]")
+                          t
+                        (error "Pos %d: Unclosed open bracket in <! tag")))
+            (if (eq (char-before) ?\[)
+                (setq depth (1+ depth))
+              (setq depth (1- depth))))
+          (search-forward ">"))))))
 
 (defsubst xml-parse-add-non-ws (text lst)
   (let ((i 0) (l (length text)) non-ws)
     (while (< i l)
       (unless (memq (aref text i) '(?\n ?\t ? ))
-	(setq i l non-ws t))
+        (setq i l non-ws t))
       (setq i (1+ i)))
     (if (not non-ws)
-	lst
+        lst
       (setcdr lst (list text))
       (cdr lst))))
 
@@ -302,75 +302,75 @@ Note that this only works if the opening tag starts at column 0."
     (goto-char beg)
     (while (search-forward "<" end t)
       (setq lst (xml-parse-add-non-ws
-		 (buffer-substring-no-properties beg (1- (point))) lst)
-	    beg (1- (point)))
+                 (buffer-substring-no-properties beg (1- (point))) lst)
+            beg (1- (point)))
       (xml-parse-skip-tag)
       (setq lst (xml-parse-add-non-ws
-		 (buffer-substring-no-properties beg (point)) lst)
-	    beg (point)))
+                 (buffer-substring-no-properties beg (point)) lst)
+            beg (point)))
     (if (/= beg end)
-	(setq lst (xml-parse-add-non-ws
-		   (buffer-substring-no-properties beg end) lst)))
+        (setq lst (xml-parse-add-non-ws
+                   (buffer-substring-no-properties beg end) lst)))
     lst))
 
 (defun xml-parse-read (&optional progress-callback)
   (let ((beg (search-forward "<" nil t)) after)
     (if progress-callback
-	(funcall progress-callback 
-		 (* (/ (float (point)) (float (point-max))) 100)))
+        (funcall progress-callback 
+                 (* (/ (float (point)) (float (point-max))) 100)))
     (while (and beg (memq (setq after (char-after)) '(?! ??)))
       (xml-parse-skip-tag)
       (setq beg (search-forward "<" nil t)))
     (when beg
       (if (eq after ?/)
-	  (progn
-	    (search-forward ">")
-	    (cons (1- beg)
-		  (buffer-substring-no-properties (1+ beg) (1- (point)))))
-	(skip-chars-forward "^ \t\n/>")
-	(cons
-	 (1- beg)
-	 (progn
-	   (setq after (point))
-	   (skip-chars-forward " \t\n")
-	   (let* ((single (eq (char-after) ?/))
-		  (tag (buffer-substring-no-properties beg after))
-		  attrs data-beg data)
-	     ;; handle the attribute list, if present
-	     (cond
-	      (single
-	       (skip-chars-forward " \t\n/>"))
-	      ((eq (char-after) ?\>)
-	       (forward-char 1))
-	      (t
-	       (let* ((attrs (list t))
-		      (lastattr attrs)
-		      (end (search-forward ">")))
-		 (goto-char after)
-		 (while (re-search-forward
-			 "\\([^ \t\n=]+\\)=\"\\([^\"]+\\)\"" end t)
-		   (let ((attr (cons (match-string-no-properties 1)
-				     (match-string-no-properties 2))))
-		     (setcdr lastattr (list attr))
-		     (setq lastattr (cdr lastattr))))
-		 (goto-char end)
-		 (setq tag (cons tag (cdr attrs))
-		       single (eq (char-before (1- end)) ?/)))))
-	     ;; return the tag and its data
-	     (if single
-		 (list tag)
-	       (setq tag (list tag))
-	       (let ((data-beg (point)) (tag-end (last tag)))
-		 (while (and (setq data (xml-parse-read progress-callback))
-			     (not (stringp (cdr data))))
-		   (setq tag-end (xml-parse-concat data-beg (car data)
-						   tag-end)
-			 data-beg (point))
-		   (setcdr tag-end (list (cdr data)))
-		   (setq tag-end (cdr tag-end)))
-		 (xml-parse-concat data-beg (or (car data)
-						(point-max)) tag-end)
-		 tag)))))))))
+          (progn
+            (search-forward ">")
+            (cons (1- beg)
+                  (buffer-substring-no-properties (1+ beg) (1- (point)))))
+        (skip-chars-forward "^ \t\n/>")
+        (cons
+         (1- beg)
+         (progn
+           (setq after (point))
+           (skip-chars-forward " \t\n")
+           (let* ((single (eq (char-after) ?/))
+                  (tag (buffer-substring-no-properties beg after))
+                  attrs data-beg data)
+             ;; handle the attribute list, if present
+             (cond
+              (single
+               (skip-chars-forward " \t\n/>"))
+              ((eq (char-after) ?\>)
+               (forward-char 1))
+              (t
+               (let* ((attrs (list t))
+                      (lastattr attrs)
+                      (end (search-forward ">")))
+                 (goto-char after)
+                 (while (re-search-forward
+                         "\\([^ \t\n=]+\\)=\"\\([^\"]+\\)\"" end t)
+                   (let ((attr (cons (match-string-no-properties 1)
+                                     (match-string-no-properties 2))))
+                     (setcdr lastattr (list attr))
+                     (setq lastattr (cdr lastattr))))
+                 (goto-char end)
+                 (setq tag (cons tag (cdr attrs))
+                       single (eq (char-before (1- end)) ?/)))))
+             ;; return the tag and its data
+             (if single
+                 (list tag)
+               (setq tag (list tag))
+               (let ((data-beg (point)) (tag-end (last tag)))
+                 (while (and (setq data (xml-parse-read progress-callback))
+                             (not (stringp (cdr data))))
+                   (setq tag-end (xml-parse-concat data-beg (car data)
+                                                   tag-end)
+                         data-beg (point))
+                   (setcdr tag-end (list (cdr data)))
+                   (setq tag-end (cdr tag-end)))
+                 (xml-parse-concat data-beg (or (car data)
+                                                (point-max)) tag-end)
+                 tag)))))))))
 
 (provide 'xml-parse)
 


### PR DESCRIPTION
- before was emacs' default indent -> 8 spaces get accumulated into one tab character
- now lisp sources are indented by using spaces exclusively. this makes sense for lisp, because it has much weirder indentation compared to other languages where every level corresponds to one tab.