### PR TITLE
Add build and lint check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,11 @@ jobs:
 
       - name: Generate the package
         run: |
-          ./bootstrap && ./configure && make
+          echo "::add-matcher::.github/workflows/problem-matchers/autotools.json"
+          ./bootstrap
+          echo "::remove-matcher owner=autotools::"
+          ./configure
+          make
 
       - name: Run checks and lint
         uses: leotaku/elisp-check@v1.4.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,9 @@ jobs:
           ./configure
           echo "::endgroup::"
           echo "::group::Building..."
+          echo "::add-matcher::.github/workflows/problem-matchers/elisp-comp.json"
           make
+          echo "::remove-matcher owner=elisp-comp::"
           echo "::endgroup::"
 
       - name: Run checks and lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,11 +55,17 @@ jobs:
 
       - name: Generate the package
         run: |
+          echo "::group::Bootstrapping..."
           echo "::add-matcher::.github/workflows/problem-matchers/autotools.json"
           ./bootstrap
           echo "::remove-matcher owner=autotools::"
+          echo "::endgroup::"
+          echo "::group::Configuring..."
           ./configure
+          echo "::endgroup::"
+          echo "::group::Building..."
           make
+          echo "::endgroup::"
 
       - name: Run checks and lint
         uses: leotaku/elisp-check@v1.4.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    name: Build and Lint Package
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        emacs_version:
+          - 24.4
+          - 24.5
+          - 25.1
+          - 25.2
+          - 25.3
+          - 26.1
+          - 26.2
+          - 26.3
+          - 27.1
+          - 27.2
+          - 28.1
+          - 28.2
+          - 29.1
+          - 29.2
+          - 29.3
+          - 29.4
+          - 30.1
+          - 30.2
+          - release-snapshot
+        experimental: [false]
+        include:
+          - emacs_version: snapshot
+            experimental: true
+
+    steps:
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Install autotools and compiler
+        run: |
+          sudo apt install \
+              build-essential autoconf automake libtool autotools-dev
+
+      - uses: actions/checkout@v5
+
+      - name: Generate the package
+        run: |
+          ./bootstrap && ./configure && make
+
+      - name: Run checks and lint
+        uses: leotaku/elisp-check@v1.4.1
+        with:
+          file: lisp/*.el
+
   gitlint:
     runs-on: ubuntu-latest
     name: GitLint

--- a/.github/workflows/problem-matchers/autotools.json
+++ b/.github/workflows/problem-matchers/autotools.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "autotools",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):\\s+(.+):\\s+(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/problem-matchers/elisp-comp.json
+++ b/.github/workflows/problem-matchers/elisp-comp.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "elisp-comp",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):(\\d+):\\s*(.+):\\s*(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This pull request adds a job to our GitHub Actions CI to build and lint the Emacs Lisp in this package against every version of Emacs since 24.4.