### PR TITLE
Remove default keybindings

### DIFF
--- a/lisp/doxymacs.el.in
+++ b/lisp/doxymacs.el.in
@@ -91,16 +91,6 @@
 ;;
 ;;   This will add the Doxygen keywords to c-mode and c++-mode only.
 ;;
-;; - Default key bindings are:
-;;   - C-c d ? will look up documentation for the symbol under the point.
-;;   - C-c d r will rescan your Doxygen tags file.
-;;   - C-c d f will insert a Doxygen comment for the next function.
-;;   - C-c d i will insert a Doxygen comment for the current file.
-;;   - C-c d ; will insert a Doxygen comment for the current member.
-;;   - C-c d m will insert a blank multiline Doxygen comment.
-;;   - C-c d s will insert a blank singleline Doxygen comment.
-;;   - C-c d @ will insert grouping comments around the current region.
-;;
 ;; Doxymacs has been tested on and works with:
 ;; - GNU Emacs 20.7.1, 21.1.1, 21.2.1, 21.2.92.1, 21.3, 21.4.1, 23.1.1
 ;;
@@ -477,10 +467,7 @@ To see what version of doxymacs you are running, enter
 `\\[doxymacs-version]'.
 
 In order for `doxymacs-lookup' to work you will need to customise the
-variable `doxymacs-doxygen-dirs'.
-
-Key bindings:
-\\{doxymacs-mode-map}"
+variable `doxymacs-doxygen-dirs'."
   (interactive "P")
   (setq doxymacs-mode
         (if (null arg)
@@ -506,41 +493,10 @@ Key bindings:
                 (append filladapt-token-table
                         (list (list bullet-regexp 'bullet)))))))))
 
-;; Keymap
-
-(defvar doxymacs-mode-map (make-sparse-keymap)
-  "Keymap for doxymacs minor mode.")
-
-(define-key doxymacs-mode-map "\C-cd?"
-            'doxymacs-lookup)
-(define-key doxymacs-mode-map "\C-cdr"
-            'doxymacs-rescan-tags)
-
-(define-key doxymacs-mode-map "\C-cd\r"
-            'doxymacs-insert-command)
-(define-key doxymacs-mode-map "\C-cdf"
-            'doxymacs-insert-function-comment)
-(define-key doxymacs-mode-map "\C-cdi"
-            'doxymacs-insert-file-comment)
-(define-key doxymacs-mode-map "\C-cdm"
-            'doxymacs-insert-blank-multiline-comment)
-(define-key doxymacs-mode-map "\C-cds"
-            'doxymacs-insert-blank-singleline-comment)
-(define-key doxymacs-mode-map "\C-cd;"
-            'doxymacs-insert-member-comment)
-(define-key doxymacs-mode-map "\C-cd@"
-            'doxymacs-insert-grouping-comments)
-
-
 ;;;###autoload
 (or (assoc 'doxymacs-mode minor-mode-alist)
     (setq minor-mode-alist
           (cons '(doxymacs-mode " doxy") minor-mode-alist)))
-
-(or (assoc 'doxymacs-mode minor-mode-map-alist)
-    (setq minor-mode-map-alist
-          (cons (cons 'doxymacs-mode doxymacs-mode-map)
-                minor-mode-map-alist)))
 
 ;; This stuff has to do with fontification
 ;; Thanks to Alec Panovici for the idea.


### PR DESCRIPTION
The default keybindings use reserved key sequences (`C-c` followed by a character), so we cannot release this as a package.  Instead, it should be up to the user to bind these keybindings in whatever major mode they are using Doxygen with.  This patch removes the minor mode’s keymap. When we are fully able to be a package, we will document the same keybindings as the recommended ones for users to configure themselves, including an example with `use-package`.