### PR TITLE
Rename vendored `xml-parse.el`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ lisp/doxymacs.elc
 lisp/elc-stamp
 lisp/Makefile
 lisp/Makefile.in
-lisp/xml-parse.elc
+lisp/doxymacs-xml-parse.elc
 Makefile
 Makefile.in
 missing

--- a/lisp/Makefile.am
+++ b/lisp/Makefile.am
@@ -1,5 +1,5 @@
 ## Process this file with automake to produce Makefile.in
 
-lisp_LISP = xml-parse.el doxymacs.el
+lisp_LISP = doxymacs-xml-parse.el doxymacs.el
 
-EXTRA_DIST = xml-parse.el
+EXTRA_DIST = doxymacs-xml-parse.el

--- a/lisp/doxymacs.el.in
+++ b/lisp/doxymacs.el.in
@@ -240,9 +240,10 @@
 (provide 'doxymacs)
 
 (require 'custom)
-(require 'xml-parse)
 (require 'url)
 (require 'tempo)
+
+(require 'doxymacs-xml-parse)
 
 (defconst doxymacs-version "@VERSION@"
   "Doxymacs version number")
@@ -884,20 +885,23 @@ completion list."
     (set-buffer tags-buffer)
     (goto-char (point-min))
     (setq doxymacs-current-completion-list nil)
-    (let ((xml (read-xml 'doxymacs-xml-progress-callback))) ;Parse the file
-      (let* ((compound-list (xml-tag-children xml))
+    (let ((xml (doxymacs-xml-parse-read-xml 'doxymacs-xml-progress-callback)))
+                                        ; Parse this file
+      (let* ((compound-list (doxymacs-xml-parse--xml-tag-children xml))
              (num-compounds (length compound-list))
              (curr-compound-num 0))
-        (if (not (string= (xml-tag-name xml) "tagfile"))
+        (if (not (string= (doxymacs-xml-parse--xml-tag-name xml) "tagfile"))
             (error (concat "Invalid tag file: " (doxymacs-filename-to-xml f)))
           ;; Go through the compounds, adding them and their members to the
           ;; completion list.
           (while compound-list
             (let* ((curr-compound (car compound-list))
-                   (compound-name (cadr (xml-tag-child curr-compound "name")))
-                   (compound-kind (xml-tag-attr curr-compound "kind"))
-                   (compound-url (cadr
-                                  (xml-tag-child curr-compound "filename")))
+                   (compound-name (cadr (doxymacs-xml-parse--xml-tag-child
+                                         curr-compound "name")))
+                   (compound-kind (doxymacs-xml-parse--xml-tag-attr
+                                   curr-compound "kind"))
+                   (compound-url (cadr (doxymacs-xml-parse--xml-tag-child
+                                        curr-compound "filename")))
                    (compound-desc (concat compound-kind " " compound-name)))
               ;; Work around apparent bug in Doxygen 1.2.18
               (if (not (string-match "\\.html$" compound-url))
@@ -938,17 +942,21 @@ completion list."
 
 (defun doxymacs-add-compound-members (compound compound-name compound-url)
   "Get the members of the given compound"
-  (let ((children (xml-tag-children compound)))
+  (let ((children (doxymacs-xml-parse--xml-tag-children compound)))
     ;; Run through the children looking for ones with the "member" tag
     (while children
       (let* ((curr-child (car children)))
-        (if (string= (xml-tag-name curr-child) "member")
+        (if (string= (doxymacs-xml-parse--xml-tag-name curr-child) "member")
             ;; Found a member.  Throw it on the list.
-            (let* ((member-name (cadr (xml-tag-child curr-child "name")))
-                   (member-anchor (cadr (xml-tag-child curr-child "anchor")))
+            (let* ((member-name (cadr (doxymacs-xml-parse--xml-tag-child
+                                       curr-child "name")))
+                   (member-anchor (cadr (doxymacs-xml-parse--xml-tag-child
+                                         curr-child "anchor")))
                    (member-url (concat compound-url "#" member-anchor))
-                   (member-args (if (cdr (xml-tag-child curr-child "arglist"))
-                                    (cadr (xml-tag-child curr-child "arglist"))
+                   (member-args (if (cdr (doxymacs-xml-parse--xml-tag-child
+                                          curr-child "arglist"))
+                                    (cadr (doxymacs-xml-parse--xml-tag-child
+                                           curr-child "arglist"))
                                   ""))
                    (member-desc (concat compound-name "::"
                                         member-name member-args)))

--- a/no-autoconf/Makefile.am
+++ b/no-autoconf/Makefile.am
@@ -4,11 +4,11 @@
 # substituted in the .el.in files for people who don't want to run
 # autoconf.
 
-EXTRA_DIST=doxymacs.el xml-parse.el
-CONFIG_CLEAN_FILES=doxymacs.el xml-parse.el
+EXTRA_DIST=doxymacs.el doxymacs-xml-parse.el
+CONFIG_CLEAN_FILES=doxymacs.el doxymacs-xml-parse.el
 
 doxymacs.el: ${top_srcdir}/lisp/doxymacs.el.in ${top_srcdir}/configure.ac
 	sed -e 's/\@VERSION\@/${VERSION}/g ; s/\@DOXYMACS_DEFAULT_STYLE\@/${DOXYMACS_DEFAULT_STYLE}/g ; s/\@DOXYMACS_USE_EXTERNAL_XML_PARSER\@/nil/g ; s/\@DOXYMACS_PARSER\@//g' < $< > $@
 
-xml-parse.el: ${top_srcdir}/lisp/xml-parse.el
+doxymacs-xml-parse.el: ${top_srcdir}/lisp/doxymacs-xml-parse.el
 	cp $< $@


### PR DESCRIPTION
Doxymacs vendors `xml-parse.el`, which was independently written by John Wiegley and distributed long before the days of real Emacs packaging. However, it does not seem to live in any package manager, so without finding an alternative to migrate to, we can’t do much about this.  In order to avoid clobbering an existing `xml-parse.el` from the user, this patch renames `xml-parse.el` to `doxymacs-xml-parse.el` and prefixes all symbols in the file with `doxymacs-xml-parse--`.

It is worth exploring using an alternative that is built-in to Emacs, like `nxml-parser.el` or the libxml2 plugin if it’s enabled (#16).  For the moment, though, it’s better to get this package building cleanly on modern Emacsen with the minimal changes needed.

Note that `xml-parse.el` is GPLv2+ itself, but any changes in this patch are licensed under GPLv3+.