### PR TITLE
chore: Update straggler references to Sourceforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ doxymacs
 doxymacs is an e-lisp package for making doxygen usage easier under GNU
 Emacs.
 
-doxymacs homepage: http://doxymacs.sourceforge.net/
+doxymacs homepage: https://pniedzielski.github.io/doxymacs/
 
 Doxymacs has been tested on and works with:
  - GNU Emacs 20.7.1, 21.1.1, 21.2.1, 21.3, 21.4.1, 23.1.1

--- a/c/doxymacs_parser.c
+++ b/c/doxymacs_parser.c
@@ -23,7 +23,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
- * Doxymacs homepage: http://doxymacs.sourceforge.net/
+ * Doxymacs homepage: https://pniedzielski.github.io/doxymacs/
  */
 
 #include <stdlib.h>

--- a/lisp/doxymacs.el
+++ b/lisp/doxymacs.el
@@ -468,7 +468,7 @@ url-1a is the associated URL.")
   ;; All of the following text shows up in the "mode help" (C-h m)
   "Minor mode for using/creating Doxygen documentation.
 To submit a problem report, request a feature or get support, please
-visit doxymacs' homepage at http://doxymacs.sourceforge.net/.
+visit doxymacs' homepage at https://pniedzielski.github.io/doxymacs/.
 
 To see what version of doxymacs you are running, enter
 `\\[doxymacs-version]'.


### PR DESCRIPTION
This package used to be hosted on Sourceforge, but is now hosted on GitHub.  This patch updates remaining existing references to the old Sourceforge website to point to the new GitHub website.