### PR TITLE
docs: Reorder arguments in documentation comments

### DIFF
--- a/lisp/doxymacs-xml-parse.el
+++ b/lisp/doxymacs-xml-parse.el
@@ -166,7 +166,7 @@ Point is left at the end of the XML structure read."
        (cdar tag)))
 
 (defsubst doxymacs-xml-parse--xml-tag-attr (tag attr)
-  "Return a specific ATTR of an xml-parse'd XML TAG."
+  "Return a specific attribute of an xml-parse'd XML TAG, named ATTR."
   (cdr (assoc attr (doxymacs-xml-parse--xml-tag-attrlist tag))))
 
 (defsubst doxymacs-xml-parse--xml-tag-children (tag)
@@ -174,7 +174,7 @@ Point is left at the end of the XML structure read."
   (cdr tag))
 
 (defun doxymacs-xml-parse--xml-tag-child (tag name)
-  "Return the first child matching NAME, of an xml-parse'd XML TAG."
+  "Return the first child of an xml-parse'd XML TAG, matching NAME."
   (catch 'found
     (let ((children (doxymacs-xml-parse--xml-tag-children tag)))
       (while children


### PR DESCRIPTION
This patch reorders the arguments in the documentation comments for `doxymacs-xml-parse--xml-tag-attr` and `doxymacs-xml-parse--xml-tag-child`, so they match the order they appear in the argument list.  This fixes warnings from checkdoc in older versions of Emacs:

    Warning: Arguments occur in the doc string out of order