### PR TITLE
fix: Add `lisp-dir` to `use-package` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ initialization file:
 ```elisp
 (use-package doxymacs
   :vc (:url "https://github.com/pniedzielski/doxymacs.git"
-            :rev :newest)
+            :rev :newest
+            :lisp-dir "lisp/")
   :hook (c-mode-common-hook . doxymacs-mode)
   :bind (:map c-mode-base-map
               ;; Lookup documentation for the symbol at point.


### PR DESCRIPTION
In order for our documented `use-package` example to work, we need to define the directory our lisp files are in.  This patch adds that to the README.