### PR TITLE
Add `doxymacs-install-external-parser`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ c/Makefile.in
 c/missing
 lisp/doxymacs.elc
 lisp/doxymacs-xml-parse.elc
+doxymacs_parser
 
 /Eldev-local
 /.eldev

--- a/README.md
+++ b/README.md
@@ -127,21 +127,30 @@ packages:
 
 Be sure these are properly configured and installed before proceeding.
 
+  - Set `doxymacs-use-external-xml-parser` to `t` and be sure to set
+    `doxymacs-external-xml-parser-executable` to where you would like the
+    external XML parser to be installed.
+
+  - Run `M-x doxymacs-install-external-parser`.
+
+If you want, you may also compile the parser manually, by performing the
+following steps:
+
   - Use the bootstrap script to generate the parser’s build system, if
     `c/configure` does not already exist
 
-        $ cd c
-        $ ./bootstrap
+       $ cd c
+       $ ./bootstrap
 
-  - Use the configure script to configure the external parser:
+ - Use the configure script to configure the external parser:
 
-        $ cd c  # If not already in c/
-        $ ./configure
-        $ make
+       $ cd c  # If not already in c/
+       $ ./configure
+       $ make
 
   - Set `doxymacs-use-external-xml-parser` to `t` and be sure to set
-    `doxymacs-external-xml-parser-executable` to the path of the
-    compiled external parser.
+    `doxymacs-external-xml-parser-executable` to the location of the external
+    XML parser.
 
 Contributing
 ------------

--- a/c/build.sh
+++ b/c/build.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+set -e
+
+./bootstrap
+./configure
+make
+cp doxymacs_parser "$1/doxymacs_parser"


### PR DESCRIPTION
This patch introduces the ability to build and install the external parser from Emacs, in the fashion of pdf-tools.  Users configure `doxymacs-external-xml-parser-executable` to whatever path they want, and then run the interactive function `doxymacs-install-external-parser` to build and install the parser to that location, if it doesn’t already exist.