### PR TITLE
Enable lexical binding by default

### DIFF
--- a/lisp/doxymacs.el
+++ b/lisp/doxymacs.el
@@ -1,4 +1,4 @@
-;;; doxymacs.el --- Emacs integration with Doxygen   -*- mode: emacs-lisp; lexical-binding: nil -*-
+;;; doxymacs.el --- Emacs integration with Doxygen   -*- mode: emacs-lisp; lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2015-2025 Patrick M. Niedzielski.
 ;; Copyright (C) 2001-2010 Ryan T. Sammartino.


### PR DESCRIPTION
This patch enables lexical binding by default in both ELisp files in the package.