### PR TITLE
Make minor mode autoloading

### DIFF
--- a/lisp/doxymacs.el
+++ b/lisp/doxymacs.el
@@ -297,8 +297,8 @@ url-1a is the associated URL.")
   "The buffer used for displaying multiple completions.")
 
 
-
 ;; Minor mode implementation
+;;;###autoload
 (define-minor-mode doxymacs-mode
   "Minor mode for using/creating Doxygen documentation.
 To submit a problem report, request a feature or get support, please


### PR DESCRIPTION
This patch makes the minor mode definition auto-loading, like the other entry point function, `doxymacs-install-external-parser`.