### PR TITLE
Switch from `master` to `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.ref }}-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Tests and Linting
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ci-${{ github.ref }}-1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Doxymacs is Doxygen + Emacs
 ===========================
 
 ![GitHub License](https://img.shields.io/github/license/pniedzielski/doxymacs)
-![GitHub branch status](https://img.shields.io/github/checks-status/pniedzielski/doxymacs/master)
+![GitHub branch status](https://img.shields.io/github/checks-status/pniedzielski/doxymacs/main)
 ![GitHub top language](https://img.shields.io/github/languages/top/pniedzielski/doxymacs)
 [![Packaging status](https://repology.org/badge/tiny-repos/emacs:doxymacs.svg)](https://repology.org/project/emacs:doxymacs/versions)
 


### PR DESCRIPTION
This pull request cleans up references to the `master` branch, and fixes a related bug on a badge in the README file.

Fixes #22.