### PR TITLE
Support for underscores in variable and exception names

### DIFF
--- a/lisp/doxymacs.el
+++ b/lisp/doxymacs.el
@@ -460,13 +460,13 @@ customize `doxymacs-use-external-xml-parser' to enable it."
    (list
     (concat "\\([@\\\\]\\(param\\(?:\\s-*\\[\\(?:in\\|out\\|in,out\\)\\]\\)?"
             "\\|tparam\\|a\\|namespace\\|relates\\(also\\)?"
-            "\\|var\\|def\\)\\)\\s-+\\(\\sw+\\)")
+            "\\|var\\|def\\)\\)\\s-\+\\(\\(\\sw\\|_\\)+\\)")
     '(1 font-lock-keyword-face prepend)
     '(4 font-lock-variable-name-face prepend))
    ;; keywords that take a type name as an argument
    (list
     (concat "\\([@\\\\]\\(class\\|struct\\|union\\|exception\\|enum"
-            "\\|throw\\|interface\\|protocol\\)\\)\\s-+\\(\\(\\sw\\|:\\)+\\)")
+            "\\|throw\\|interface\\|protocol\\)\\)\\s-+\\(\\(\\sw\\|:\\|_\\)+\\)")
     '(1 font-lock-keyword-face prepend)
     '(3 font-lock-type-face prepend))
    ;; keywords that take a function name as an argument


### PR DESCRIPTION
This adds support for syntax highlighting variables (and exception) names with underscores. Before this patch, a line such as `@param variable_name description of variable_name.` would highlight "@param" and "variable" as expected, but would highlight "_name" as if it were part of "description of variable_name."

A similar case would happen with `\exception std::out_of_range parameter is out of range` (an example from the doxygen page [here](https://www.doxygen.nl/manual/commands.html#cmdfn))

An example of the before and after cases is below:
Before:
<img width="1044" height="127" alt="image" src="https://github.com/user-attachments/assets/e60a81e9-d206-423f-9212-d1efc0ca1c4c" />
After:
<img width="1049" height="123" alt="image" src="https://github.com/user-attachments/assets/4634c7fb-c2ef-4d96-9b60-ac1e5b51a972" />
